### PR TITLE
vmm-sys-util: remove inactive CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/vmm-sys-util/ @liujing2 @sameo @andreeaflorescu @jiangliu @roypat @ShadowCurse
+/vmm-sys-util/ @andreeaflorescu @ShadowCurse


### PR DESCRIPTION
Remove inactive vmm-sys-util CODEOWNERS who were notified in https://github.com/rust-vmm/rust-vmm/issues/22.

Changes:

- Removed inactive CODEOWNERS: @liujing2 @sameo @jiangliu @roypat

Notification:

All affected CODEOWNERS were notified on 2026-05-26 via https://github.com/rust-vmm/rust-vmm/issues/22 and given a 1-month period to respond.

Policy Reference:

This removal follows our Inactive CODEOWNERS Policy [1].

A big thank you to @liujing2, @sameo, @jiangliu, and @roypat for all their contributions and the time spent maintaining vmm-sys-util over the years. You are always welcome to come back whenever you have time and interest, just open a PR or ping the current maintainers to be re-added.

[1] https://github.com/rust-vmm/community/blob/main/MAINTAINERS.md#inactive-codeowners-policy

Closes: rust-vmm#22
