### PR TITLE
vmm-sys-util: remove extern crate from doc examples

### DIFF
--- a/vmm-sys-util/src/errno.rs
+++ b/vmm-sys-util/src/errno.rs
@@ -37,9 +37,6 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// # extern crate libc;
-    /// extern crate vmm_sys_util;
-    /// #
     /// # use libc;
     /// use vmm_sys_util::errno::Error;
     ///
@@ -59,9 +56,6 @@ impl Error {
     /// # Examples
     ///
     /// ```
-    /// # extern crate libc;
-    /// extern crate vmm_sys_util;
-    /// #
     /// # use libc;
     /// # use std::fs::File;
     /// # use std::io::{self, Read};
@@ -91,7 +85,6 @@ impl Error {
     ///
     /// # Examples
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::errno::Error;
     ///
     /// let err = Error::new(13);

--- a/vmm-sys-util/src/linux/aio.rs
+++ b/vmm-sys-util/src/linux/aio.rs
@@ -108,7 +108,6 @@ impl IoContext {
     ///
     /// # Examples
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::aio::*;
     /// # use std::fs::File;
     /// # use std::os::unix::io::AsRawFd;
@@ -181,7 +180,6 @@ impl IoContext {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::aio::*;
     /// # use std::fs::File;
     /// # use std::os::unix::io::AsRawFd;

--- a/vmm-sys-util/src/linux/epoll.rs
+++ b/vmm-sys-util/src/linux/epoll.rs
@@ -111,7 +111,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
     ///
     /// let event = EpollEvent::new(EventSet::IN, 2);
@@ -129,7 +128,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
     ///
     /// let event = EpollEvent::new(EventSet::IN, 2);
@@ -149,7 +147,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
     ///
     /// let event = EpollEvent::new(EventSet::IN, 2);
@@ -167,7 +164,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
     ///
     /// let event = EpollEvent::new(EventSet::IN, 2);
@@ -185,7 +181,6 @@ impl EpollEvent {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::epoll::{EpollEvent, EventSet};
     ///
     /// let event = EpollEvent::new(EventSet::IN, 2);
@@ -227,8 +222,6 @@ impl Epoll {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    ///
     /// use std::os::unix::io::AsRawFd;
     /// use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
     /// use vmm_sys_util::eventfd::EventFd;
@@ -280,8 +273,6 @@ impl Epoll {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
-    ///
     /// use std::os::unix::io::AsRawFd;
     /// use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
     /// use vmm_sys_util::eventfd::EventFd;

--- a/vmm-sys-util/src/linux/eventfd.rs
+++ b/vmm-sys-util/src/linux/eventfd.rs
@@ -34,7 +34,6 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     ///
     /// EventFd::new(EFD_NONBLOCK).unwrap();
@@ -68,7 +67,6 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     ///
     /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
@@ -87,7 +85,6 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     ///
     /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();
@@ -108,7 +105,6 @@ impl EventFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
     ///
     /// let evt = EventFd::new(EFD_NONBLOCK).unwrap();

--- a/vmm-sys-util/src/linux/fallocate.rs
+++ b/vmm-sys-util/src/linux/fallocate.rs
@@ -38,7 +38,6 @@ pub enum FallocateMode {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
 /// # use std::fs::OpenOptions;
 /// # use std::path::PathBuf;
 /// use vmm_sys_util::fallocate::{fallocate, FallocateMode};

--- a/vmm-sys-util/src/linux/ioctl.rs
+++ b/vmm-sys-util/src/linux/ioctl.rs
@@ -20,7 +20,8 @@ use std::os::unix::io::AsRawFd;
 /// [_IOC](https://elixir.bootlin.com/linux/v5.10.129/source/arch/alpha/include/uapi/asm/ioctl.h#L40)
 /// ```
 /// # use std::os::raw::c_uint;
-/// # use vmm_sys_util::ioctl::{ioctl_expr, _IOC_NONE};
+/// use vmm_sys_util::ioctl::{ioctl_expr, _IOC_NONE};
+///
 /// const KVMIO: c_uint = 0xAE;
 /// ioctl_expr(_IOC_NONE, KVMIO, 0x01, 0);
 /// ```
@@ -39,9 +40,9 @@ pub const fn ioctl_expr(
 /// Declare a function that returns an ioctl number.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
 /// # use std::os::raw::c_uint;
 /// use vmm_sys_util::ioctl::_IOC_NONE;
+/// use vmm_sys_util::ioctl_ioc_nr;
 ///
 /// const KVMIO: c_uint = 0xAE;
 /// ioctl_ioc_nr!(KVM_CREATE_VM, _IOC_NONE, KVMIO, 0x01, 0);
@@ -67,8 +68,9 @@ macro_rules! ioctl_ioc_nr {
 /// Declare an ioctl that transfers no data.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
 /// # use std::os::raw::c_uint;
+/// use vmm_sys_util::ioctl_io_nr;
+///
 /// const KVMIO: c_uint = 0xAE;
 /// ioctl_io_nr!(KVM_CREATE_VM, KVMIO, 0x01);
 /// ```
@@ -85,7 +87,8 @@ macro_rules! ioctl_io_nr {
 /// Declare an ioctl that reads data.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
+/// use vmm_sys_util::ioctl_ior_nr;
+///
 /// const TUNTAP: ::std::os::raw::c_uint = 0x54;
 /// ioctl_ior_nr!(TUNGETFEATURES, TUNTAP, 0xcf, ::std::os::raw::c_uint);
 /// ```
@@ -115,7 +118,8 @@ macro_rules! ioctl_ior_nr {
 /// Declare an ioctl that writes data.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
+/// use vmm_sys_util::ioctl_iow_nr;
+///
 /// const TUNTAP: ::std::os::raw::c_uint = 0x54;
 /// ioctl_iow_nr!(TUNSETQUEUE, TUNTAP, 0xd9, ::std::os::raw::c_int);
 /// ```
@@ -145,7 +149,8 @@ macro_rules! ioctl_iow_nr {
 /// Declare an ioctl that reads and writes data.
 ///
 /// ```
-/// # #[macro_use] extern crate vmm_sys_util;
+/// use vmm_sys_util::ioctl_iowr_nr;
+///
 /// const VHOST: ::std::os::raw::c_uint = 0xAF;
 /// ioctl_iowr_nr!(VHOST_GET_VRING_BASE, VHOST, 0x12, ::std::os::raw::c_int);
 /// ```
@@ -227,14 +232,12 @@ type IoctlRequest = c_int;
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// # #[macro_use] extern crate vmm_sys_util;
-/// #
 /// # use libc::{open, O_CLOEXEC, O_RDWR};
 /// # use std::fs::File;
 /// # use std::os::raw::{c_char, c_uint};
 /// # use std::os::unix::io::FromRawFd;
 /// use vmm_sys_util::ioctl::ioctl;
+/// use vmm_sys_util::ioctl_io_nr;
 ///
 /// const KVMIO: c_uint = 0xAE;
 /// const KVM_API_VERSION: u32 = 12;
@@ -269,13 +272,12 @@ pub unsafe fn ioctl<F: AsRawFd>(fd: &F, req: c_ulong) -> c_int {
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// # #[macro_use] extern crate vmm_sys_util;
 /// # use libc::{open, O_CLOEXEC, O_RDWR};
 /// # use std::fs::File;
 /// # use std::os::raw::{c_char, c_uint, c_ulong};
 /// # use std::os::unix::io::FromRawFd;
 /// use vmm_sys_util::ioctl::ioctl_with_val;
+/// use vmm_sys_util::ioctl_io_nr;
 ///
 /// const KVMIO: c_uint = 0xAE;
 /// const KVM_CAP_USER_MEMORY: u32 = 3;

--- a/vmm-sys-util/src/linux/poll.rs
+++ b/vmm-sys-util/src/linux/poll.rs
@@ -374,7 +374,6 @@ impl WatchingEvents {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
 /// use vmm_sys_util::eventfd::EventFd;
 /// use vmm_sys_util::poll::{EpollContext, EpollEvents};
 ///
@@ -405,7 +404,6 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::poll::EpollContext;
     ///
     /// let ctx: EpollContext<usize> = EpollContext::new().unwrap();
@@ -439,7 +437,6 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::eventfd::EventFd;
     /// use vmm_sys_util::poll::EpollContext;
     ///
@@ -468,7 +465,6 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::eventfd::EventFd;
     /// use vmm_sys_util::poll::{EpollContext, WatchingEvents};
     ///
@@ -517,7 +513,6 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::eventfd::EventFd;
     /// use vmm_sys_util::poll::{EpollContext, WatchingEvents};
     ///
@@ -563,7 +558,6 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::eventfd::EventFd;
     /// use vmm_sys_util::poll::EpollContext;
     ///
@@ -604,7 +598,6 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// use vmm_sys_util::eventfd::EventFd;
     /// use vmm_sys_util::poll::{EpollContext, EpollEvents};
     ///
@@ -637,7 +630,6 @@ impl<T: PollToken> EpollContext<T> {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// use vmm_sys_util::eventfd::EventFd;
     /// use vmm_sys_util::poll::{EpollContext, EpollEvents};
@@ -719,9 +711,10 @@ impl<T: PollToken> IntoRawFd for EpollContext<T> {
 /// # Example
 ///
 /// ```
-/// # use vmm_sys_util::errno::Result;
-/// # use vmm_sys_util::eventfd::EventFd;
-/// # use vmm_sys_util::poll::{PollContext, PollEvents};
+/// use vmm_sys_util::errno::Result;
+/// use vmm_sys_util::eventfd::EventFd;
+/// use vmm_sys_util::poll::{PollContext, PollEvents};
+///
 /// let evt1 = EventFd::new(0).unwrap();
 /// let evt2 = EventFd::new(0).unwrap();
 /// evt2.write(1).unwrap();

--- a/vmm-sys-util/src/linux/signal.rs
+++ b/vmm-sys-util/src/linux/signal.rs
@@ -117,7 +117,6 @@ pub fn SIGRTMAX() -> c_int {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
 /// use vmm_sys_util::signal::validate_signal_num;
 ///
 /// let num = validate_signal_num(1).unwrap();
@@ -146,8 +145,6 @@ pub fn validate_signal_num(num: c_int) -> errno::Result<()> {
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// extern crate vmm_sys_util;
 /// # use libc::{c_int, c_void, siginfo_t, SA_SIGINFO};
 /// use vmm_sys_util::signal::{register_signal_handler, SignalHandler};
 ///
@@ -197,8 +194,6 @@ pub fn register_signal_handler(num: c_int, handler: SignalHandler) -> errno::Res
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// extern crate vmm_sys_util;
 /// # use libc::sigismember;
 /// use vmm_sys_util::signal::create_sigset;
 ///
@@ -238,7 +233,6 @@ pub fn create_sigset(signals: &[c_int]) -> errno::Result<sigset_t> {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
 /// use vmm_sys_util::signal::{block_signal, get_blocked_signals};
 ///
 /// block_signal(1).unwrap();
@@ -278,7 +272,6 @@ pub fn get_blocked_signals() -> SignalResult<Vec<c_int>> {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
 /// use vmm_sys_util::signal::block_signal;
 ///
 /// block_signal(1).unwrap();
@@ -316,7 +309,6 @@ pub fn block_signal(num: c_int) -> SignalResult<()> {
 /// # Examples
 ///
 /// ```
-/// extern crate vmm_sys_util;
 /// use vmm_sys_util::signal::{block_signal, get_blocked_signals, unblock_signal};
 ///
 /// block_signal(1).unwrap();
@@ -343,8 +335,6 @@ pub fn unblock_signal(num: c_int) -> SignalResult<()> {
 /// # Examples
 ///
 /// ```
-/// # extern crate libc;
-/// extern crate vmm_sys_util;
 /// # use libc::{pthread_kill, sigismember, sigpending, sigset_t};
 /// # use std::mem;
 /// # use std::thread;

--- a/vmm-sys-util/src/linux/timerfd.rs
+++ b/vmm-sys-util/src/linux/timerfd.rs
@@ -73,7 +73,6 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// use vmm_sys_util::timerfd::TimerFd;
     ///
@@ -125,7 +124,6 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// # use std::thread::sleep;
     /// use vmm_sys_util::timerfd::TimerFd;
@@ -156,7 +154,6 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// use vmm_sys_util::timerfd::TimerFd;
     ///
@@ -187,7 +184,6 @@ impl TimerFd {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// # use std::time::Duration;
     /// use vmm_sys_util::timerfd::TimerFd;
     ///

--- a/vmm-sys-util/src/unix/terminal.rs
+++ b/vmm-sys-util/src/unix/terminal.rs
@@ -122,7 +122,6 @@ pub unsafe trait Terminal {
     /// # Examples
     ///
     /// ```
-    /// extern crate vmm_sys_util;
     /// # use std::io;
     /// # use std::os::unix::io::RawFd;
     /// use vmm_sys_util::terminal::Terminal;


### PR DESCRIPTION
### Summary of the PR

Remove all `extern crate` lines from vmm-sys-util doc examples, as they
are unnecessary in Rust edition 2021. Replace `#[macro_use] extern crate`
in ioctl.rs with explicit `use vmm_sys_util::<macro>;` imports. Unhide
`use` lines whose items are visibly referenced in example code, and drop
hidden imports that are unused.

Fixes #5