### PR TITLE
vmm-sys-util: remove `bincode`

### DIFF
--- a/vmm-sys-util/Cargo.toml
+++ b/vmm-sys-util/Cargo.toml
@@ -24,4 +24,3 @@ bitflags = "1.0"
 
 [dev-dependencies]
 serde_json = "1.0.9"
-bincode = "1.3.3"

--- a/vmm-sys-util/src/fam.rs
+++ b/vmm-sys-util/src/fam.rs
@@ -1168,20 +1168,22 @@ mod tests {
         struct Foo {
             pub len: u32,
             pub padding: u32,
+            #[serde(skip)]
             pub entries: __IncompleteArrayField<u32>,
         }
 
         generate_fam_struct_impl!(Foo, u32, entries, u32, len, 100);
 
         let state = FamStructWrapper::<Foo>::new(0).unwrap();
-        let mut bytes = bincode::serialize(&state).unwrap();
+        let serialized = serde_json::to_string(&state).unwrap();
 
-        // The `len` field of the header is the first to be serialized.
-        // Writing at position 0 of the serialized data should change its value.
-        bytes[0] = 255;
+        let serialized = serialized.replace("\"len\":0", "\"len\":255");
 
         assert!(
-            matches!(bincode::deserialize::<FamStructWrapper<Foo>>(&bytes).map_err(|boxed| *boxed), Err(bincode::ErrorKind::Custom(s)) if s == *"Mismatch between length of FAM specified in FamStruct header (255) and actual size of FAM (0)")
+            serde_json::from_str::<FamStructWrapper<Foo>>(&serialized)
+            .unwrap_err()
+            .to_string()
+            .contains("Mismatch between length of FAM specified in FamStruct header (255) and actual size of FAM (0)")
         );
     }
 }


### PR DESCRIPTION
### Summary of the PR

Removes `bincode`.

Fixes: https://github.com/rust-vmm/rust-vmm/issues/54

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
