### PR TITLE
Rename `with-serde` feature to `serde`

### DIFF
--- a/vmm-sys-util/CHANGELOG.md
+++ b/vmm-sys-util/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [[#254](https://github.com/rust-vmm/vmm-sys-util/pull/254)]: Support `TFD_NONBLOCK` for `timerfd::TimerFd`.
 
+### Changed
+
+- [[#56](https://github.com/rust-vmm/rust-vmm/pull/56)]: Rename `with-serde` Cargo feature references to `serde` in the FAM module.
+
 ## v0.15.0
 
 ### Added

--- a/vmm-sys-util/Cargo.toml
+++ b/vmm-sys-util/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-with-serde = ["serde", "serde_derive"]
+serde = ["dep:serde", "serde_derive"]
 
 [dependencies]
 libc = "0.2.127"

--- a/vmm-sys-util/src/fam.rs
+++ b/vmm-sys-util/src/fam.rs
@@ -16,13 +16,13 @@
 //!
 //! For example the KVM API has many structures of this kind.
 
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 use serde::de::{self, Deserialize, Deserializer, SeqAccess, Visitor};
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 use serde::{ser::SerializeTuple, Serialize, Serializer};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 use std::marker::PhantomData;
 use std::mem::{self, size_of};
 
@@ -548,7 +548,7 @@ impl<T: Default + FamStruct> Clone for FamStructWrapper<T> {
     }
 }
 
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 impl<T: Default + FamStruct + Serialize> Serialize for FamStructWrapper<T>
 where
     <T as FamStruct>::Entry: serde::Serialize,
@@ -564,7 +564,7 @@ where
     }
 }
 
-#[cfg(feature = "with-serde")]
+#[cfg(feature = "serde")]
 impl<'de, T: Default + FamStruct + Deserialize<'de>> Deserialize<'de> for FamStructWrapper<T>
 where
     <T as FamStruct>::Entry: std::marker::Copy + serde::Deserialize<'de>,
@@ -658,7 +658,7 @@ macro_rules! generate_fam_struct_impl {
 mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     use serde_derive::{Deserialize, Serialize};
 
     use super::*;
@@ -691,7 +691,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     impl<T> Serialize for __IncompleteArrayField<T> {
         fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
         where
@@ -701,7 +701,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     impl<'de, T> Deserialize<'de> for __IncompleteArrayField<T> {
         fn deserialize<D>(_: D) -> std::result::Result<Self, D::Error>
         where
@@ -1027,17 +1027,17 @@ mod tests {
         assert_eq!(data[0].padding, 5);
     }
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_ser_deser() {
         #[repr(C)]
         #[derive(Default, PartialEq)]
-        #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+        #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
         struct Message {
             pub len: u32,
             pub padding: u32,
             pub value: u32,
-            #[cfg_attr(feature = "with-serde", serde(skip))]
+            #[cfg_attr(feature = "serde", serde(skip))]
             pub entries: __IncompleteArrayField<u32>,
         }
 
@@ -1075,12 +1075,12 @@ mod tests {
 
         #[repr(C)]
         #[derive(Default)]
-        #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+        #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
         struct Message2 {
             pub len: u32,
             pub padding: u32,
             pub value: u32,
-            #[cfg_attr(feature = "with-serde", serde(skip))]
+            #[cfg_attr(feature = "serde", serde(skip))]
             pub entries: __IncompleteArrayField<u32>,
         }
 
@@ -1160,7 +1160,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "with-serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn test_bad_deserialize() {
         #[repr(C)]


### PR DESCRIPTION
### Summary of the PR

Rename all conditional compilation attributes in the FAM module from
`feature = "with-serde"` to `feature = "serde"`.

This aligns the implementation and tests with the renamed Cargo feature,
ensuring serde support is compiled under the correct feature flag

Fixes https://github.com/rust-vmm/rust-vmm/issues/10