### PR TITLE
vmm-sys-util: remove inner `with-serde` cfg in tests

### DIFF
--- a/vmm-sys-util/src/fam.rs
+++ b/vmm-sys-util/src/fam.rs
@@ -1031,13 +1031,12 @@ mod tests {
     #[test]
     fn test_ser_deser() {
         #[repr(C)]
-        #[derive(Default, PartialEq)]
-        #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+        #[derive(Default, PartialEq, Deserialize, Serialize)]
         struct Message {
             pub len: u32,
             pub padding: u32,
             pub value: u32,
-            #[cfg_attr(feature = "with-serde", serde(skip))]
+            #[serde(skip)]
             pub entries: __IncompleteArrayField<u32>,
         }
 
@@ -1074,13 +1073,12 @@ mod tests {
         assert!(serde_json::from_str::<MessageFamStructWrapper>(bad_data_ser).is_err());
 
         #[repr(C)]
-        #[derive(Default)]
-        #[cfg_attr(feature = "with-serde", derive(Deserialize, Serialize))]
+        #[derive(Default, Deserialize, Serialize)]
         struct Message2 {
             pub len: u32,
             pub padding: u32,
             pub value: u32,
-            #[cfg_attr(feature = "with-serde", serde(skip))]
+            #[serde(skip)]
             pub entries: __IncompleteArrayField<u32>,
         }
 


### PR DESCRIPTION
### Summary of the PR

`#[cfg_attr(feature = "with-serde",...)]` within a test gated on `#[cfg(feature = "with-serde")]` only inhibits readability. If the test is active, then so are the attributes.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
