### PR TITLE
vmm-sys-util: Mark `IoContext::submit` as unsafe

### DIFF
--- a/vmm-sys-util/CHANGELOG.md
+++ b/vmm-sys-util/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - [[#254](https://github.com/rust-vmm/vmm-sys-util/pull/254)]: Support `TFD_NONBLOCK` for `timerfd::TimerFd`.
 
+### Changed
+
+- [[#25](https://github.com/rust-vmm/vmm-sys-util/issues/25)]: Mark
+  `linux::aio::IoContext::submit` as unsafe to reflect that callers must uphold
+  the safety requirements for submitted buffers.
+
 ## v0.15.0
 
 ### Added

--- a/vmm-sys-util/src/linux/aio.rs
+++ b/vmm-sys-util/src/linux/aio.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Alibaba Cloud Computing. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-//! Safe wrapper over [`Linux AIO`](http://man7.org/linux/man-pages/man7/aio.7.html).
+//! Wrapper over [`Linux AIO`](http://man7.org/linux/man-pages/man7/aio.7.html).
 
 #![allow(non_camel_case_types)]
 
@@ -106,6 +106,11 @@ impl IoContext {
     /// # Arguments
     /// * `iocbs`: array of AIO control blocks, which will be submitted to the context.
     ///
+    /// # Safety
+    /// The caller must ensure that every buffer referenced by `iocbs` remains valid until the
+    /// kernel signals the operation is done via a completion. Read ops need exclusive ownership and
+    /// Write ops need shared ownership for the duration of the op.
+    ///
     /// # Examples
     /// ```
     /// use vmm_sys_util::aio::*;
@@ -122,10 +127,12 @@ impl IoContext {
     ///     aio_nbytes: buf.len() as u64,
     ///     ..Default::default()
     /// }];
-    /// assert_eq!(ctx.submit(&iocbs[..]).unwrap(), 1);
+    /// // SAFETY: The buffer is kept alive and exclusively owned until the operation is complete.
+    /// assert_eq!(unsafe { ctx.submit(&iocbs[..]) }.unwrap(), 1);
     /// ```
-    pub fn submit(&self, iocbs: &[&mut IoControlBlock]) -> Result<usize> {
-        // SAFETY: It's safe because parameters are valid and we have checked the result.
+    pub unsafe fn submit(&self, iocbs: &[&mut IoControlBlock]) -> Result<usize> {
+        // SAFETY: The caller guarantees that the referenced memory remains valid until the kernel
+        // completes the operations.
         let rc = unsafe {
             libc::syscall(
                 libc::SYS_io_submit,
@@ -186,25 +193,27 @@ impl IoContext {
     ///
     /// let file = File::open("/dev/zero").unwrap();
     /// let ctx = IoContext::new(128).unwrap();
-    /// let mut buf: [u8; 4096] = unsafe { std::mem::uninitialized() };
+    /// let mut buf1: [u8; 4096] = unsafe { std::mem::uninitialized() };
+    /// let mut buf2: [u8; 4096] = unsafe { std::mem::uninitialized() };
     /// let iocbs = [
     ///     &mut IoControlBlock {
     ///         aio_fildes: file.as_raw_fd() as u32,
     ///         aio_lio_opcode: IOCB_CMD_PREAD as u16,
-    ///         aio_buf: buf.as_mut_ptr() as u64,
-    ///         aio_nbytes: buf.len() as u64,
+    ///         aio_buf: buf1.as_mut_ptr() as u64,
+    ///         aio_nbytes: buf1.len() as u64,
     ///         ..Default::default()
     ///     },
     ///     &mut IoControlBlock {
     ///         aio_fildes: file.as_raw_fd() as u32,
     ///         aio_lio_opcode: IOCB_CMD_PREAD as u16,
-    ///         aio_buf: buf.as_mut_ptr() as u64,
-    ///         aio_nbytes: buf.len() as u64,
+    ///         aio_buf: buf2.as_mut_ptr() as u64,
+    ///         aio_nbytes: buf2.len() as u64,
     ///         ..Default::default()
     ///     },
     /// ];
     ///
-    /// let mut rc = ctx.submit(&iocbs[..]).unwrap();
+    /// // SAFETY: The referenced buffers live until both operations are complete.
+    /// let mut rc = unsafe { ctx.submit(&iocbs[..]) }.unwrap();
     /// let mut events = [unsafe { std::mem::uninitialized::<IoEvent>() }];
     /// rc = ctx.get_events(1, &mut events, None).unwrap();
     /// assert_eq!(rc, 1);
@@ -277,7 +286,8 @@ mod test {
             ..Default::default()
         }];
 
-        let mut rc = ctx.submit(&iocbs).unwrap();
+        // SAFETY: The referenced buffer lives until the operation is complete.
+        let mut rc = unsafe { ctx.submit(&iocbs) }.unwrap();
         assert_eq!(rc, 1);
 
         let mut result = Default::default();
@@ -299,25 +309,27 @@ mod test {
         let file = File::open("/dev/zero").unwrap();
 
         let ctx = IoContext::new(128).unwrap();
-        let mut buf: [u8; 4096] = [0u8; 4096];
+        let mut buf1: [u8; 4096] = [0u8; 4096];
+        let mut buf2: [u8; 4096] = [0u8; 4096];
         let iocbs = [
             &mut IoControlBlock {
                 aio_fildes: file.as_raw_fd() as u32,
                 aio_lio_opcode: IOCB_CMD_PREAD as u16,
-                aio_buf: buf.as_mut_ptr() as u64,
-                aio_nbytes: buf.len() as u64,
+                aio_buf: buf1.as_mut_ptr() as u64,
+                aio_nbytes: buf1.len() as u64,
                 ..Default::default()
             },
             &mut IoControlBlock {
                 aio_fildes: file.as_raw_fd() as u32,
                 aio_lio_opcode: IOCB_CMD_PREAD as u16,
-                aio_buf: buf.as_mut_ptr() as u64,
-                aio_nbytes: buf.len() as u64,
+                aio_buf: buf2.as_mut_ptr() as u64,
+                aio_nbytes: buf2.len() as u64,
                 ..Default::default()
             },
         ];
 
-        let mut rc = ctx.submit(&iocbs[..]).unwrap();
+        // SAFETY: The referenced buffers live until both operations are complete.
+        let mut rc = unsafe { ctx.submit(&iocbs[..]) }.unwrap();
         assert_eq!(rc, 2);
 
         let mut events = [IoEvent::default()];

--- a/vmm-sys-util/src/linux/aio.rs
+++ b/vmm-sys-util/src/linux/aio.rs
@@ -113,18 +113,20 @@ impl IoContext {
     ///
     /// # Examples
     /// ```
+    /// use std::mem::MaybeUninit;
     /// use vmm_sys_util::aio::*;
     /// # use std::fs::File;
     /// # use std::os::unix::io::AsRawFd;
     ///
     /// let file = File::open("/dev/zero").unwrap();
     /// let ctx = IoContext::new(128).unwrap();
-    /// let mut buf: [u8; 4096] = unsafe { std::mem::uninitialized() };
+    /// const BUF_LEN: usize = 4096;
+    /// let mut buf = MaybeUninit::<[u8; BUF_LEN]>::uninit();
     /// let iocbs = [&mut IoControlBlock {
     ///     aio_fildes: file.as_raw_fd() as u32,
     ///     aio_lio_opcode: IOCB_CMD_PREAD as u16,
-    ///     aio_buf: buf.as_mut_ptr() as u64,
-    ///     aio_nbytes: buf.len() as u64,
+    ///     aio_buf: buf.as_mut_ptr() as *mut u8 as u64,
+    ///     aio_nbytes: BUF_LEN as u64,
     ///     ..Default::default()
     /// }];
     /// // SAFETY: The buffer is kept alive and exclusively owned until the operation is complete.
@@ -187,34 +189,36 @@ impl IoContext {
     /// # Examples
     ///
     /// ```
+    /// use std::mem::MaybeUninit;
     /// use vmm_sys_util::aio::*;
     /// # use std::fs::File;
     /// # use std::os::unix::io::AsRawFd;
     ///
     /// let file = File::open("/dev/zero").unwrap();
     /// let ctx = IoContext::new(128).unwrap();
-    /// let mut buf1: [u8; 4096] = unsafe { std::mem::uninitialized() };
-    /// let mut buf2: [u8; 4096] = unsafe { std::mem::uninitialized() };
+    /// const BUF_LEN: usize = 4096;
+    /// let mut buf1 = MaybeUninit::<[u8; BUF_LEN]>::uninit();
+    /// let mut buf2 = MaybeUninit::<[u8; BUF_LEN]>::uninit();
     /// let iocbs = [
     ///     &mut IoControlBlock {
     ///         aio_fildes: file.as_raw_fd() as u32,
     ///         aio_lio_opcode: IOCB_CMD_PREAD as u16,
-    ///         aio_buf: buf1.as_mut_ptr() as u64,
-    ///         aio_nbytes: buf1.len() as u64,
+    ///         aio_buf: buf1.as_mut_ptr() as *mut u8 as u64,
+    ///         aio_nbytes: BUF_LEN as u64,
     ///         ..Default::default()
     ///     },
     ///     &mut IoControlBlock {
     ///         aio_fildes: file.as_raw_fd() as u32,
     ///         aio_lio_opcode: IOCB_CMD_PREAD as u16,
-    ///         aio_buf: buf2.as_mut_ptr() as u64,
-    ///         aio_nbytes: buf2.len() as u64,
+    ///         aio_buf: buf2.as_mut_ptr() as *mut u8 as u64,
+    ///         aio_nbytes: BUF_LEN as u64,
     ///         ..Default::default()
     ///     },
     /// ];
     ///
     /// // SAFETY: The referenced buffers live until both operations are complete.
     /// let mut rc = unsafe { ctx.submit(&iocbs[..]) }.unwrap();
-    /// let mut events = [unsafe { std::mem::uninitialized::<IoEvent>() }];
+    /// let mut events = [IoEvent::default()];
     /// rc = ctx.get_events(1, &mut events, None).unwrap();
     /// assert_eq!(rc, 1);
     /// assert!(events[0].res > 0);


### PR DESCRIPTION
### Summary of the PR

IOContext::submit was marked safe, but writes to raw pointers unbound by rust's lifetimes. Mark it unsafe

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [-] All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] Any newly added `unsafe` code is properly documented.
