### PR TITLE
vm-memory: Make the 'rawfd' feature a NOP on windows

### DIFF
--- a/vm-memory/CHANGELOG.md
+++ b/vm-memory/CHANGELOG.md
@@ -11,6 +11,7 @@ However, common interfaces such as `GuestAddressSpace` and `Bytes` remain on
 `GuestMemory`; therefore, all callers that just use the `Bytes` interface
 remain completely unchanged.
 
+- \[[#63](https://github.com/rust-vmm/rust-vmm/pull/63)\] Make the 'rawfd' feature a NOP on Windows
 - \[[#362](https://github.com/rust-vmm/vm-memory/pull/362)\] Rename `GuestMemory` to `GuestMemoryBackend`, `IoMemory` to `GuestMemory`
 
 ### Added

--- a/vm-memory/benches/mmap/mod.rs
+++ b/vm-memory/benches/mmap/mod.rs
@@ -7,11 +7,11 @@
 extern crate criterion;
 extern crate vm_memory;
 
-#[cfg(feature = "rawfd")]
+#[cfg(all(feature = "rawfd", not(target_os = "windows")))]
 use std::fs::{File, OpenOptions};
 use std::mem::size_of;
 
-#[cfg(feature = "rawfd")]
+#[cfg(all(feature = "rawfd", not(target_os = "windows")))]
 use std::path::Path;
 
 use core::hint::black_box;
@@ -88,9 +88,9 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
     let mut image = make_image(ACCESS_SIZE);
     let buf = &mut [0u8; ACCESS_SIZE];
 
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     let mut file = File::open(Path::new("/dev/zero")).expect("Could not open /dev/zero");
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     let mut file_to_write = OpenOptions::new()
         .write(true)
         .open("/dev/null")
@@ -116,7 +116,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
             })
         });
 
-        #[cfg(feature = "rawfd")]
+        #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
         c.bench_function(format!("read_from_file_{offset:#0X}").as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)
@@ -165,7 +165,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
             })
         });
 
-        #[cfg(feature = "rawfd")]
+        #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
         c.bench_function(format!("write_to_file_{offset:#0X}").as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)

--- a/vm-memory/src/io.rs
+++ b/vm-memory/src/io.rs
@@ -8,10 +8,10 @@ use crate::volatile_memory::copy_slice_impl::{copy_from_volatile_slice, copy_to_
 use crate::{VolatileMemoryError, VolatileSlice};
 use std::io::{Cursor, ErrorKind};
 
-#[cfg(feature = "rawfd")]
+#[cfg(all(feature = "rawfd", not(target_os = "windows")))]
 use std::io::Stdout;
 
-#[cfg(feature = "rawfd")]
+#[cfg(all(feature = "rawfd", not(target_os = "windows")))]
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
 
 macro_rules! retry_eintr {
@@ -131,7 +131,7 @@ pub trait WriteVolatile {
 
 macro_rules! impl_read_write_volatile_for_raw_fd {
     ($raw_fd_ty:ty) => {
-        #[cfg(feature = "rawfd")]
+        #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
         impl ReadVolatile for $raw_fd_ty {
             fn read_volatile<B: BitmapSlice>(
                 &mut self,
@@ -141,7 +141,7 @@ macro_rules! impl_read_write_volatile_for_raw_fd {
             }
         }
 
-        #[cfg(feature = "rawfd")]
+        #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
         impl ReadVolatile for &$raw_fd_ty {
             fn read_volatile<B: BitmapSlice>(
                 &mut self,
@@ -151,7 +151,7 @@ macro_rules! impl_read_write_volatile_for_raw_fd {
             }
         }
 
-        #[cfg(feature = "rawfd")]
+        #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
         impl ReadVolatile for &mut $raw_fd_ty {
             fn read_volatile<B: BitmapSlice>(
                 &mut self,
@@ -161,7 +161,7 @@ macro_rules! impl_read_write_volatile_for_raw_fd {
             }
         }
 
-        #[cfg(feature = "rawfd")]
+        #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
         impl WriteVolatile for $raw_fd_ty {
             fn write_volatile<B: BitmapSlice>(
                 &mut self,
@@ -171,7 +171,7 @@ macro_rules! impl_read_write_volatile_for_raw_fd {
             }
         }
 
-        #[cfg(feature = "rawfd")]
+        #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
         impl WriteVolatile for &$raw_fd_ty {
             fn write_volatile<B: BitmapSlice>(
                 &mut self,
@@ -181,7 +181,7 @@ macro_rules! impl_read_write_volatile_for_raw_fd {
             }
         }
 
-        #[cfg(feature = "rawfd")]
+        #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
         impl WriteVolatile for &mut $raw_fd_ty {
             fn write_volatile<B: BitmapSlice>(
                 &mut self,
@@ -193,7 +193,7 @@ macro_rules! impl_read_write_volatile_for_raw_fd {
     };
 }
 
-#[cfg(feature = "rawfd")]
+#[cfg(all(feature = "rawfd", not(target_os = "windows")))]
 impl WriteVolatile for Stdout {
     fn write_volatile<B: BitmapSlice>(
         &mut self,
@@ -203,7 +203,7 @@ impl WriteVolatile for Stdout {
     }
 }
 
-#[cfg(feature = "rawfd")]
+#[cfg(all(feature = "rawfd", not(target_os = "windows")))]
 impl WriteVolatile for &Stdout {
     fn write_volatile<B: BitmapSlice>(
         &mut self,
@@ -223,7 +223,7 @@ impl_read_write_volatile_for_raw_fd!(std::os::fd::BorrowedFd<'_>);
 /// the given [`VolatileSlice`].
 ///
 /// Returns the numbers of bytes read.
-#[cfg(feature = "rawfd")]
+#[cfg(all(feature = "rawfd", not(target_os = "windows")))]
 fn read_volatile_raw_fd(
     raw_fd: BorrowedFd<'_>,
     buf: &mut VolatileSlice<impl BitmapSlice>,
@@ -254,7 +254,7 @@ fn read_volatile_raw_fd(
 /// data stored in the given [`VolatileSlice`].
 ///
 /// Returns the numbers of bytes written.
-#[cfg(feature = "rawfd")]
+#[cfg(all(feature = "rawfd", not(target_os = "windows")))]
 fn write_volatile_raw_fd(
     raw_fd: BorrowedFd<'_>,
     buf: &VolatileSlice<impl BitmapSlice>,
@@ -435,9 +435,9 @@ mod tests {
     use crate::io::{ReadVolatile, WriteVolatile};
     use crate::{VolatileMemoryError, VolatileSlice};
     use std::io::{Cursor, ErrorKind};
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     use std::io::{Read, Seek, Write};
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     use vmm_sys_util::tempfile::TempFile;
 
     // ---- Test ReadVolatile for &[u8] ----
@@ -474,7 +474,7 @@ mod tests {
     }
 
     // ---- Test ReadVolatile for File ----
-    #[cfg(all(feature = "rawfd", not(miri)))]
+    #[cfg(all(feature = "rawfd", not(miri), not(target_os = "windows")))]
     fn read_4_bytes_from_file(source: Vec<u8>, expected_output: [u8; 5]) {
         let mut temp_file = TempFile::new().unwrap().into_file();
         temp_file.write_all(source.as_ref()).unwrap();
@@ -518,7 +518,7 @@ mod tests {
 
         for (input, output) in test_cases {
             read_4_bytes_to_5_byte_memory(input.clone(), output);
-            #[cfg(all(feature = "rawfd", not(miri)))]
+            #[cfg(all(feature = "rawfd", not(miri), not(target_os = "windows")))]
             read_4_bytes_from_file(input, output);
         }
     }
@@ -559,7 +559,7 @@ mod tests {
     }
 
     // ---- Test ẂriteVolatile for File works ----
-    #[cfg(all(feature = "rawfd", not(miri)))]
+    #[cfg(all(feature = "rawfd", not(miri), not(target_os = "windows")))]
     fn write_5_bytes_to_file(mut source: Vec<u8>) {
         // Test write_volatile for File works
         let mut temp_file = TempFile::new().unwrap().into_file();
@@ -603,7 +603,7 @@ mod tests {
 
         for (input, output) in test_cases {
             write_4_bytes_to_5_byte_vec(input.clone(), output);
-            #[cfg(all(feature = "rawfd", not(miri)))]
+            #[cfg(all(feature = "rawfd", not(miri), not(target_os = "windows")))]
             write_5_bytes_to_file(input);
         }
     }

--- a/vm-memory/src/lib.rs
+++ b/vm-memory/src/lib.rs
@@ -25,9 +25,6 @@
 #[cfg(not(target_pointer_width = "64"))]
 compile_error!("vm-memory only supports 64-bit targets!");
 
-#[cfg(all(target_family = "windows", feature = "rawfd"))]
-compile_error!("rawfd feature is not supported on Windows targets!");
-
 #[cfg(all(target_family = "windows", feature = "xen"))]
 compile_error!("xen feature is not supported on Windows targets!");
 

--- a/vm-memory/src/mmap/mod.rs
+++ b/vm-memory/src/mmap/mod.rs
@@ -242,7 +242,7 @@ mod tests {
     use crate::{Bytes, GuestMemoryBackend, GuestMemoryError};
 
     use std::io::Write;
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     use std::{fs::File, path::Path};
     use vmm_sys_util::tempfile::TempFile;
 
@@ -473,7 +473,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     #[cfg(not(miri))]
     fn read_to_and_write_from_mem() {
         use std::mem;

--- a/vm-memory/src/volatile_memory.rs
+++ b/vm-memory/src/volatile_memory.rs
@@ -1466,11 +1466,11 @@ mod tests {
     use super::*;
     use std::alloc::Layout;
 
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     use std::fs::File;
     #[cfg(feature = "backend-bitmap")]
     use std::mem::size_of_val;
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     use std::path::Path;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Barrier};
@@ -1479,7 +1479,7 @@ mod tests {
     use matches::assert_matches;
     #[cfg(feature = "backend-bitmap")]
     use std::num::NonZeroUsize;
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     use vmm_sys_util::tempfile::TempFile;
 
     #[cfg(feature = "backend-bitmap")]
@@ -1972,7 +1972,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "rawfd")]
+    #[cfg(all(feature = "rawfd", not(target_os = "windows")))]
     fn mem_read_and_write() {
         let mut backing = vec![0u8; 5];
         let a = VolatileSlice::from(backing.as_mut_slice());


### PR DESCRIPTION
### Summary of the PR

When `rawfd' feature was introduced on commit 0b7a4377, it was enabled by default to avoid breaking the default behavior on linux. So, on Windows, vm-memory must be included with 'default-features = false' otherwise it fails to compile. This is problematic for projects that depend indirectly on vm-memory and fail if their dependencies don't set 'default-features = false'.

Since there is no current way to set the default feature set for a specific target OS, let's make the 'rawfd' feature a NOP for Windows builds, the feature will still be enabled, but silently just not do anything.


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
