### PR TITLE
vm-allocator: bump edition to 2021

### DIFF
--- a/vm-allocator/CHANGELOG.md
+++ b/vm-allocator/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 ### Changed
+
+- Crate is now using edition 2021.
+
 ### Fixed
 ### Removed
 ### Deprecated

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 readme = "README.md"
 keywords = ["resources", "allocation", "address", "virt"]
 license = "Apache-2.0 OR BSD-3-Clause"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Follow-up to the vm-allocator mono-repo migration, as requested in review: https://github.com/rust-vmm/rust-vmm/pull/107#discussion_r3828578731.

`vm-allocator` was the only crate left in the workspace on edition 2018 — `acpi_tables`, `event-manager`, `linux-loader`, `seccompiler`, `vm-memory` and `vmm-sys-util` are all on 2021 already.

The switch is a no-op for the crate. Verified locally:

- `cargo all-features build --release --all-targets` with `RUSTFLAGS="-D warnings"` — clean across all four feature combinations (`[]`, `[serde]`, `[std]`, `[serde,std]`)
- `cargo all-features clippy --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks` — clean
- `cargo all-features test` — 40 unit tests + 3 doc tests pass in every combination
- `cargo fmt --all -- --check`, `cargo check --workspace --all-targets` and `cargo doc --workspace --all-features --no-deps` — clean
- line coverage unchanged at 95.73%, so `coverage_config_{x86_64,aarch64}.json` need no re-baselining

The CHANGELOG entry follows what the other crates did for their own edition bumps (`linux-loader`, `vm-memory`, `vmm-sys-util`, `seccompiler`).

Closes rust-vmm/rust-vmm#106 

cc @stefano-garzarella @andreeaflorescu
