### PR TITLE
acpi_tables: add firmware platform table support

### DIFF
--- a/acpi_tables/CHANGELOG.md
+++ b/acpi_tables/CHANGELOG.md
@@ -6,6 +6,7 @@
   timing, and thermal-zone operations.
 - Added GPIO interrupt, GPIO I/O, I2C, and SPI resource descriptors.
 - Added a fixed-size buffer implementation of `AmlSink`.
+- Added revision 3 Generic Timer Description Table generation.
 
 ## Fixed
 

--- a/acpi_tables/CHANGELOG.md
+++ b/acpi_tables/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Upcoming Release
+
+## Fixed
+
+- Fixed the AML opcode ordering for `PowerResource` objects.

--- a/acpi_tables/CHANGELOG.md
+++ b/acpi_tables/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added GPIO interrupt, GPIO I/O, I2C, and SPI resource descriptors.
 - Added a fixed-size buffer implementation of `AmlSink`.
 - Added revision 3 Generic Timer Description Table generation.
+- Added IO Remapping Table generation for PCI-to-GIC ITS mappings.
 
 ## Fixed
 

--- a/acpi_tables/CHANGELOG.md
+++ b/acpi_tables/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Upcoming Release
 
+## Added
+
+- Added AML encoders for commonly used control, reference, arithmetic,
+  timing, and thermal-zone operations.
+
 ## Fixed
 
 - Fixed the AML opcode ordering for `PowerResource` objects.

--- a/acpi_tables/CHANGELOG.md
+++ b/acpi_tables/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added revision 3 Generic Timer Description Table generation.
 - Added IO Remapping Table generation for PCI-to-GIC ITS mappings.
 - Added Debug Port Table 2 generation for ARM PL011 UARTs.
+- Added Serial Port Console Redirection Table generation for ARM PL011 UARTs.
 
 ## Fixed
 

--- a/acpi_tables/CHANGELOG.md
+++ b/acpi_tables/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added IO Remapping Table generation for PCI-to-GIC ITS mappings.
 - Added Debug Port Table 2 generation for ARM PL011 UARTs.
 - Added Serial Port Console Redirection Table generation for ARM PL011 UARTs.
+- Added High Precision Event Timer table generation.
 
 ## Fixed
 

--- a/acpi_tables/CHANGELOG.md
+++ b/acpi_tables/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added AML encoders for commonly used control, reference, arithmetic,
   timing, and thermal-zone operations.
 - Added GPIO interrupt, GPIO I/O, I2C, and SPI resource descriptors.
+- Added a fixed-size buffer implementation of `AmlSink`.
 
 ## Fixed
 

--- a/acpi_tables/CHANGELOG.md
+++ b/acpi_tables/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added a fixed-size buffer implementation of `AmlSink`.
 - Added revision 3 Generic Timer Description Table generation.
 - Added IO Remapping Table generation for PCI-to-GIC ITS mappings.
+- Added Debug Port Table 2 generation for ARM PL011 UARTs.
 
 ## Fixed
 

--- a/acpi_tables/CHANGELOG.md
+++ b/acpi_tables/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added AML encoders for commonly used control, reference, arithmetic,
   timing, and thermal-zone operations.
+- Added GPIO interrupt, GPIO I/O, I2C, and SPI resource descriptors.
 
 ## Fixed
 

--- a/acpi_tables/coverage_config_aarch64.json
+++ b/acpi_tables/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.11,
+  "coverage_score": 92.26,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_aarch64.json
+++ b/acpi_tables/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.45,
+  "coverage_score": 92.55,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_aarch64.json
+++ b/acpi_tables/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.61,
+  "coverage_score": 91.65,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_aarch64.json
+++ b/acpi_tables/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.36,
+  "coverage_score": 92.45,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_aarch64.json
+++ b/acpi_tables/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.41,
+  "coverage_score": 91.61,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_aarch64.json
+++ b/acpi_tables/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.31,
+  "coverage_score": 91.41,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_aarch64.json
+++ b/acpi_tables/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90.87,
+  "coverage_score": 91.31,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_aarch64.json
+++ b/acpi_tables/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.65,
+  "coverage_score": 92.11,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_aarch64.json
+++ b/acpi_tables/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.26,
+  "coverage_score": 92.36,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_x86_64.json
+++ b/acpi_tables/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.11,
+  "coverage_score": 92.26,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_x86_64.json
+++ b/acpi_tables/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.45,
+  "coverage_score": 92.55,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_x86_64.json
+++ b/acpi_tables/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.61,
+  "coverage_score": 91.65,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_x86_64.json
+++ b/acpi_tables/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.36,
+  "coverage_score": 92.45,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_x86_64.json
+++ b/acpi_tables/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.41,
+  "coverage_score": 91.61,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_x86_64.json
+++ b/acpi_tables/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.31,
+  "coverage_score": 91.41,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_x86_64.json
+++ b/acpi_tables/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90.87,
+  "coverage_score": 91.31,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_x86_64.json
+++ b/acpi_tables/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.65,
+  "coverage_score": 92.11,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/coverage_config_x86_64.json
+++ b/acpi_tables/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.26,
+  "coverage_score": 92.36,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -32,21 +32,29 @@ const NAMECHARBASE: u8 = 0x40;
 
 const EXTOPPREFIX: u8 = 0x5b;
 const MUTEXOP: u8 = 0x01;
+const CONDREFOFOP: u8 = 0x12;
 const CREATEFIELDOP: u8 = 0x13;
+const STALLOP: u8 = 0x21;
+const SLEEPOP: u8 = 0x22;
 const ACQUIREOP: u8 = 0x23;
 const RELEASEOP: u8 = 0x27;
 const OPREGIONOP: u8 = 0x80;
 const FIELDOP: u8 = 0x81;
 const DEVICEOP: u8 = 0x82;
 const POWERRESOURCEOP: u8 = 0x84;
+const THERMALZONEOP: u8 = 0x85;
 
 const LOCAL0OP: u8 = 0x60;
 const ARG0OP: u8 = 0x68;
 const STOREOP: u8 = 0x70;
+const REFOFOP: u8 = 0x71;
 const ADDOP: u8 = 0x72;
 const CONCATOP: u8 = 0x73;
 const SUBTRACTOP: u8 = 0x74;
+const INCREMENTOP: u8 = 0x75;
+const DECREMENTOP: u8 = 0x76;
 const MULTIPLYOP: u8 = 0x77;
+const DIVIDEOP: u8 = 0x78;
 const SHIFTLEFTOP: u8 = 0x79;
 const SHIFTRIGHTOP: u8 = 0x7a;
 const ANDOP: u8 = 0x7b;
@@ -77,6 +85,7 @@ const IFOP: u8 = 0xa0;
 const ELSEOP: u8 = 0xa1;
 const WHILEOP: u8 = 0xa2;
 const RETURNOP: u8 = 0xa4;
+const BREAKOP: u8 = 0xa5;
 const ONESOP: u8 = 0xff;
 
 // AML resouce data fields
@@ -1252,6 +1261,55 @@ impl Aml for Store<'_> {
     }
 }
 
+/// Conditionally create a reference to an object if it exists.
+pub struct CondRefOf<'a> {
+    source: &'a dyn Aml,
+    target: &'a dyn Aml,
+}
+
+impl<'a> CondRefOf<'a> {
+    /// Create a conditional reference from `source` into `target`.
+    pub fn new(source: &'a dyn Aml, target: &'a dyn Aml) -> Self {
+        Self { source, target }
+    }
+}
+
+impl Aml for CondRefOf<'_> {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        sink.byte(EXTOPPREFIX);
+        sink.byte(CONDREFOFOP);
+        self.source.to_aml_bytes(sink);
+        self.target.to_aml_bytes(sink);
+    }
+}
+
+macro_rules! extended_object_op {
+    ($name:ident, $opcode:expr) => {
+        /// Extended operation on an AML object.
+        pub struct $name<'a> {
+            object: &'a dyn Aml,
+        }
+
+        impl<'a> $name<'a> {
+            /// Create the extended object operation.
+            pub fn new(object: &'a dyn Aml) -> Self {
+                Self { object }
+            }
+        }
+
+        impl Aml for $name<'_> {
+            fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+                sink.byte(EXTOPPREFIX);
+                sink.byte($opcode);
+                self.object.to_aml_bytes(sink);
+            }
+        }
+    };
+}
+
+extended_object_op!(Stall, STALLOP);
+extended_object_op!(Sleep, SLEEPOP);
+
 /// Mutex object with a mutex name and a synchronization level.
 pub struct Mutex {
     path: Path,
@@ -1370,6 +1428,15 @@ impl Aml for While<'_> {
     }
 }
 
+/// Terminate the innermost enclosing [`While`] loop.
+pub struct Break;
+
+impl Aml for Break {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        sink.byte(BREAKOP);
+    }
+}
+
 macro_rules! object_op {
     ($name:ident, $opcode:expr) => {
         /// General operation on a object.
@@ -1393,6 +1460,9 @@ macro_rules! object_op {
     };
 }
 
+object_op!(RefOf, REFOFOP);
+object_op!(Increment, INCREMENTOP);
+object_op!(Decrement, DECREMENTOP);
 object_op!(ObjectType, OBJECTTYPEOP);
 object_op!(SizeOf, SIZEOFOP);
 object_op!(Return, RETURNOP);
@@ -1443,6 +1513,41 @@ binary_op!(Index, INDEXOP);
 binary_op!(ToString, TOSTRINGOP);
 binary_op!(CreateDWordField, CREATEDWFIELDOP);
 binary_op!(CreateQWordField, CREATEQWFIELDOP);
+
+/// Divide two AML integers and store both the remainder and quotient.
+pub struct Divide<'a> {
+    dividend: &'a dyn Aml,
+    divisor: &'a dyn Aml,
+    remainder: &'a dyn Aml,
+    quotient: &'a dyn Aml,
+}
+
+impl<'a> Divide<'a> {
+    /// Create a divide operation.
+    pub fn new(
+        dividend: &'a dyn Aml,
+        divisor: &'a dyn Aml,
+        remainder: &'a dyn Aml,
+        quotient: &'a dyn Aml,
+    ) -> Self {
+        Self {
+            dividend,
+            divisor,
+            remainder,
+            quotient,
+        }
+    }
+}
+
+impl Aml for Divide<'_> {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        sink.byte(DIVIDEOP);
+        self.dividend.to_aml_bytes(sink);
+        self.divisor.to_aml_bytes(sink);
+        self.remainder.to_aml_bytes(sink);
+        self.quotient.to_aml_bytes(sink);
+    }
+}
 
 macro_rules! convert_op {
     ($name:ident, $opcode:expr) => {
@@ -1686,6 +1791,35 @@ impl Uuid {
 impl Aml for Uuid {
     fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
         self.name.to_aml_bytes(sink)
+    }
+}
+
+/// Thermal Zone object containing thermal control methods and values.
+pub struct ThermalZone<'a> {
+    name: Path,
+    children: Vec<&'a dyn Aml>,
+}
+
+impl<'a> ThermalZone<'a> {
+    /// Create a Thermal Zone object.
+    pub fn new(name: Path, children: Vec<&'a dyn Aml>) -> Self {
+        Self { name, children }
+    }
+}
+
+impl Aml for ThermalZone<'_> {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        let mut bytes = Vec::new();
+        self.name.to_aml_bytes(&mut bytes);
+        for child in &self.children {
+            child.to_aml_bytes(&mut bytes);
+        }
+
+        let pkg_length = create_pkg_length(bytes.len(), true);
+        sink.byte(EXTOPPREFIX);
+        sink.byte(THERMALZONEOP);
+        sink.vec(&pkg_length);
+        sink.vec(&bytes);
     }
 }
 
@@ -2695,6 +2829,37 @@ mod tests {
             builder.add_element(&5u8);
             builder.to_aml_bytes(&mut aml);
             assert_eq!(expected, aml);
+        }
+    }
+
+    #[test]
+    fn test_additional_aml_operations() {
+        let name = Path::new("OBJ0");
+        let local0 = Local(0);
+        let local1 = Local(1);
+
+        let cases: &[(&dyn Aml, &[u8])] = &[
+            (&Break, b"\xa5"),
+            (&RefOf::new(&name), b"\x71OBJ0"),
+            (&Increment::new(&local0), b"\x75\x60"),
+            (&Decrement::new(&local1), b"\x76\x61"),
+            (&Stall::new(&10u8), b"\x5b\x21\x0a\x0a"),
+            (&Sleep::new(&100u8), b"\x5b\x22\x0a\x64"),
+            (&CondRefOf::new(&name, &local0), b"\x5b\x12OBJ0\x60"),
+            (
+                &Divide::new(&10u8, &3u8, &local0, &local1),
+                b"\x78\x0a\x0a\x0a\x03\x60\x61",
+            ),
+            (
+                &ThermalZone::new(Path::new("TZ00"), vec![]),
+                b"\x5b\x85\x05TZ00",
+            ),
+        ];
+
+        for (aml, expected) in cases {
+            let mut bytes = Vec::new();
+            aml.to_aml_bytes(&mut bytes);
+            assert_eq!(&bytes, expected);
         }
     }
 

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -97,6 +97,8 @@ const DWORDADDRSPACEDESC: u8 = 0x87;
 const WORDADDRSPACEDESC: u8 = 0x88;
 const EXTIRQDESC: u8 = 0x89;
 const QWORDADDRSPACEDESC: u8 = 0x8A;
+const GPIOCONNECTIONDESC: u8 = 0x8C;
+const SERIALBUSCONNECTIONDESC: u8 = 0x8E;
 
 /// Zero object in ASL.
 pub const ZERO: Zero = Zero {};
@@ -828,6 +830,223 @@ impl Aml for IrqNoFlags {
     fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
         sink.byte(IRQNOFLAGSDESC); /* IRQNoFlags Descriptor */
         write_irq_mask_bytes(self.number, sink);
+    }
+}
+
+/// GPIO interrupt trigger mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GpioIntMode {
+    Level = 0,
+    Edge = 1,
+}
+
+/// GPIO interrupt polarity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GpioIntPolarity {
+    ActiveHigh = 0,
+    ActiveLow = 1,
+    ActiveBoth = 2,
+}
+
+/// GPIO pin pull configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GpioPinConfig {
+    Default = 0,
+    PullUp = 1,
+    PullDown = 2,
+    PullNone = 3,
+}
+
+/// GPIO I/O restriction mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GpioIoRestriction {
+    None = 0,
+    InputOnly = 1,
+    OutputOnly = 2,
+    Preserve = 3,
+}
+
+/// GPIO Interrupt Connection resource descriptor.
+pub struct GpioInt<'a> {
+    pub resource_source: &'a str,
+    pub pins: &'a [u16],
+    pub consumer: bool,
+    pub mode: GpioIntMode,
+    pub polarity: GpioIntPolarity,
+    pub shared: bool,
+    pub pin_config: GpioPinConfig,
+    pub debounce: u16,
+}
+
+impl Aml for GpioInt<'_> {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        const PIN_TABLE_OFFSET: u16 = 23;
+
+        let pin_table_size = u16::try_from(self.pins.len() * 2).unwrap();
+        let resource_source_size = u16::try_from(self.resource_source.len() + 1).unwrap();
+        let resource_source_offset = PIN_TABLE_OFFSET.checked_add(pin_table_size).unwrap();
+        let vendor_data_offset = resource_source_offset
+            .checked_add(resource_source_size)
+            .unwrap();
+
+        sink.byte(GPIOCONNECTIONDESC);
+        sink.word(vendor_data_offset - 3);
+        sink.byte(1); // Revision ID
+        sink.byte(0); // Interrupt connection
+        sink.word(self.consumer as u16);
+        sink.word(self.mode as u16 | ((self.polarity as u16) << 1) | ((self.shared as u16) << 3));
+        sink.byte(self.pin_config as u8);
+        sink.word(0); // Output drive strength
+        sink.word(self.debounce);
+        sink.word(PIN_TABLE_OFFSET);
+        sink.byte(0); // Resource source index
+        sink.word(resource_source_offset);
+        sink.word(vendor_data_offset);
+        sink.word(0); // Vendor data length
+        for &pin in self.pins {
+            sink.word(pin);
+        }
+        sink.vec(self.resource_source.as_bytes());
+        sink.byte(0);
+    }
+}
+
+/// GPIO I/O Connection resource descriptor.
+pub struct GpioIo<'a> {
+    pub resource_source: &'a str,
+    pub pins: &'a [u16],
+    pub consumer: bool,
+    pub io_restriction: GpioIoRestriction,
+    pub pin_config: GpioPinConfig,
+    pub drive_strength: u16,
+    pub debounce: u16,
+}
+
+impl Aml for GpioIo<'_> {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        const PIN_TABLE_OFFSET: u16 = 23;
+
+        let pin_table_size = u16::try_from(self.pins.len() * 2).unwrap();
+        let resource_source_size = u16::try_from(self.resource_source.len() + 1).unwrap();
+        let resource_source_offset = PIN_TABLE_OFFSET.checked_add(pin_table_size).unwrap();
+        let vendor_data_offset = resource_source_offset
+            .checked_add(resource_source_size)
+            .unwrap();
+
+        sink.byte(GPIOCONNECTIONDESC);
+        sink.word(vendor_data_offset - 3);
+        sink.byte(1); // Revision ID
+        sink.byte(1); // I/O connection
+        sink.word(self.consumer as u16);
+        sink.word(self.io_restriction as u16);
+        sink.byte(self.pin_config as u8);
+        sink.word(self.drive_strength);
+        sink.word(self.debounce);
+        sink.word(PIN_TABLE_OFFSET);
+        sink.byte(0); // Resource source index
+        sink.word(resource_source_offset);
+        sink.word(vendor_data_offset);
+        sink.word(0); // Vendor data length
+        for &pin in self.pins {
+            sink.word(pin);
+        }
+        sink.vec(self.resource_source.as_bytes());
+        sink.byte(0);
+    }
+}
+
+/// I2C Serial Bus Connection resource descriptor.
+pub struct I2cSerialBus<'a> {
+    pub resource_source: &'a str,
+    pub slave_address: u16,
+    pub connection_speed: u32,
+    pub address_10bit: bool,
+    pub consumer: bool,
+}
+
+impl Aml for I2cSerialBus<'_> {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        const TYPE_DATA_LENGTH: u16 = 6;
+
+        let data_length = 9 + TYPE_DATA_LENGTH as usize + self.resource_source.len() + 1;
+        sink.byte(SERIALBUSCONNECTIONDESC);
+        sink.word(u16::try_from(data_length).unwrap());
+        sink.byte(1); // Revision ID
+        sink.byte(0); // Resource source index
+        sink.byte(1); // I2C
+        sink.byte((self.consumer as u8) << 1);
+        sink.word(self.address_10bit as u16);
+        sink.byte(1); // Type-specific revision ID
+        sink.word(TYPE_DATA_LENGTH);
+        sink.dword(self.connection_speed);
+        sink.word(self.slave_address);
+        sink.vec(self.resource_source.as_bytes());
+        sink.byte(0);
+    }
+}
+
+/// SPI clock phase.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpiClockPhase {
+    First = 0,
+    Second = 1,
+}
+
+/// SPI clock polarity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpiClockPolarity {
+    Low = 0,
+    High = 1,
+}
+
+/// SPI wire mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpiWireMode {
+    FourWire = 0,
+    ThreeWire = 1,
+}
+
+/// SPI chip-select polarity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpiDevicePolarity {
+    ActiveLow = 0,
+    ActiveHigh = 1,
+}
+
+/// SPI Serial Bus Connection resource descriptor.
+pub struct SpiSerialBus<'a> {
+    pub resource_source: &'a str,
+    pub connection_speed: u32,
+    pub data_bit_length: u8,
+    pub clock_phase: SpiClockPhase,
+    pub clock_polarity: SpiClockPolarity,
+    pub wire_mode: SpiWireMode,
+    pub device_polarity: SpiDevicePolarity,
+    pub device_selection: u16,
+    pub consumer: bool,
+}
+
+impl Aml for SpiSerialBus<'_> {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        const TYPE_DATA_LENGTH: u16 = 9;
+
+        let data_length = 9 + TYPE_DATA_LENGTH as usize + self.resource_source.len() + 1;
+        sink.byte(SERIALBUSCONNECTIONDESC);
+        sink.word(u16::try_from(data_length).unwrap());
+        sink.byte(1); // Revision ID
+        sink.byte(0); // Resource source index
+        sink.byte(2); // SPI
+        sink.byte((self.consumer as u8) << 1);
+        sink.word(self.wire_mode as u16 | ((self.device_polarity as u16) << 1));
+        sink.byte(1); // Type-specific revision ID
+        sink.word(TYPE_DATA_LENGTH);
+        sink.dword(self.connection_speed);
+        sink.byte(self.data_bit_length);
+        sink.byte(self.clock_phase as u8);
+        sink.byte(self.clock_polarity as u8);
+        sink.word(self.device_selection);
+        sink.vec(self.resource_source.as_bytes());
+        sink.byte(0);
     }
 }
 
@@ -1962,6 +2181,96 @@ mod tests {
         ];
         let bytes = Scope::raw("_SB_.MBRD".into(), vec![0xAA, 0xBB, 0xCC, 0xDD]);
         assert_eq!(bytes, scope);
+    }
+
+    #[test]
+    fn test_gpio_connection_descriptors() {
+        let gpio_int = GpioInt {
+            resource_source: "\\_SB.GPI0",
+            pins: &[42],
+            consumer: true,
+            mode: GpioIntMode::Edge,
+            polarity: GpioIntPolarity::ActiveLow,
+            shared: false,
+            pin_config: GpioPinConfig::PullUp,
+            debounce: 0,
+        };
+        let gpio_io = GpioIo {
+            resource_source: "\\_SB.GPI0",
+            pins: &[10, 11],
+            consumer: true,
+            io_restriction: GpioIoRestriction::None,
+            pin_config: GpioPinConfig::Default,
+            drive_strength: 0,
+            debounce: 0,
+        };
+
+        let mut bytes = Vec::new();
+        gpio_int.to_aml_bytes(&mut bytes);
+        assert_eq!(
+            bytes,
+            b"\x8c\x20\x00\x01\x00\x01\x00\x03\x00\x01\x00\x00\x00\x00\x17\x00\x00\x19\x00\x23\x00\x00\x00\x2a\x00\\_SB.GPI0\x00"
+        );
+
+        bytes.clear();
+        gpio_io.to_aml_bytes(&mut bytes);
+        assert_eq!(
+            bytes,
+            b"\x8c\x22\x00\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x17\x00\x00\x1b\x00\x25\x00\x00\x00\x0a\x00\x0b\x00\\_SB.GPI0\x00"
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_gpio_connection_descriptor_rejects_offset_overflow() {
+        let resource_source = "a".repeat(u16::MAX as usize - 1);
+        GpioInt {
+            resource_source: &resource_source,
+            pins: &[],
+            consumer: true,
+            mode: GpioIntMode::Level,
+            polarity: GpioIntPolarity::ActiveHigh,
+            shared: false,
+            pin_config: GpioPinConfig::Default,
+            debounce: 0,
+        }
+        .to_aml_bytes(&mut Vec::new());
+    }
+
+    #[test]
+    fn test_serial_bus_connection_descriptors() {
+        let i2c = I2cSerialBus {
+            resource_source: "\\_SB.I2C0",
+            slave_address: 0x50,
+            connection_speed: 400_000,
+            address_10bit: false,
+            consumer: true,
+        };
+        let spi = SpiSerialBus {
+            resource_source: "\\_SB.SPI0",
+            connection_speed: 10_000_000,
+            data_bit_length: 8,
+            clock_phase: SpiClockPhase::First,
+            clock_polarity: SpiClockPolarity::Low,
+            wire_mode: SpiWireMode::FourWire,
+            device_polarity: SpiDevicePolarity::ActiveLow,
+            device_selection: 0,
+            consumer: true,
+        };
+
+        let mut bytes = Vec::new();
+        i2c.to_aml_bytes(&mut bytes);
+        assert_eq!(
+            bytes,
+            b"\x8e\x19\x00\x01\x00\x01\x02\x00\x00\x01\x06\x00\x80\x1a\x06\x00\x50\x00\\_SB.I2C0\x00"
+        );
+
+        bytes.clear();
+        spi.to_aml_bytes(&mut bytes);
+        assert_eq!(
+            bytes,
+            b"\x8e\x1c\x00\x01\x00\x02\x02\x00\x00\x01\x09\x00\x80\x96\x98\x00\x08\x00\x00\x00\x00\\_SB.SPI0\x00"
+        );
     }
 
     #[test]

--- a/acpi_tables/src/aml.rs
+++ b/acpi_tables/src/aml.rs
@@ -1729,8 +1729,8 @@ impl Aml for PowerResource<'_> {
         // PkgLength
         let pkg_length = create_pkg_length(bytes.len(), true);
 
-        sink.byte(POWERRESOURCEOP);
         sink.byte(EXTOPPREFIX);
+        sink.byte(POWERRESOURCEOP);
         sink.vec(&pkg_length);
         sink.vec(&bytes);
     }
@@ -2696,6 +2696,16 @@ mod tests {
             builder.to_aml_bytes(&mut aml);
             assert_eq!(expected, aml);
         }
+    }
+
+    #[test]
+    fn test_power_resource() {
+        let power_resource = PowerResource::new(Path::new("PWR0"), 0, 0, vec![]);
+        let mut aml = Vec::new();
+
+        power_resource.to_aml_bytes(&mut aml);
+
+        assert_eq!(aml, b"\x5b\x84\x08PWR0\x00\x00\x00");
     }
 
     #[test]

--- a/acpi_tables/src/dbg2.rs
+++ b/acpi_tables/src/dbg2.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 Arthur Heymans
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Debug Port Table 2 (DBG2).
+
+extern crate alloc;
+
+use crate::{sdt::GenericAddress, sdt::Sdt, Aml, AmlSink};
+
+const TABLE_HEADER_LENGTH: usize = 44;
+const DEVICE_INFO_LENGTH: usize = 22;
+const GAS_LENGTH: usize = 12;
+const ADDRESS_SIZE_LENGTH: usize = 4;
+
+/// PL011 debug port configuration.
+pub struct Pl011Config<'a> {
+    pub base_address: u64,
+    pub address_size: u32,
+    pub namespace: &'a str,
+}
+
+/// Debug Port Table 2.
+pub struct DBG2 {
+    table: Sdt,
+}
+
+impl DBG2 {
+    /// Create a DBG2 containing one ARM PL011 debug port.
+    pub fn pl011(
+        oem_id: [u8; 6],
+        oem_table_id: [u8; 8],
+        oem_revision: u32,
+        config: Pl011Config<'_>,
+    ) -> Self {
+        let namespace_length = u16::try_from(config.namespace.len() + 1).unwrap();
+        let device_length = u16::try_from(
+            DEVICE_INFO_LENGTH + GAS_LENGTH + ADDRESS_SIZE_LENGTH + usize::from(namespace_length),
+        )
+        .unwrap();
+        let mut table = Sdt::new(
+            *b"DBG2",
+            (TABLE_HEADER_LENGTH + usize::from(device_length)) as u32,
+            0,
+            oem_id,
+            oem_table_id,
+            oem_revision,
+        );
+
+        table.write_u32(36, TABLE_HEADER_LENGTH as u32);
+        table.write_u32(40, 1);
+
+        let device = TABLE_HEADER_LENGTH;
+        let base_address_offset = DEVICE_INFO_LENGTH as u16;
+        let address_size_offset = base_address_offset + GAS_LENGTH as u16;
+        let namespace_offset = address_size_offset + ADDRESS_SIZE_LENGTH as u16;
+
+        table.write_u8(device, 0); // Device information revision
+        table.write_u16(device + 1, device_length);
+        table.write_u8(device + 3, 1); // Address count
+        table.write_u16(device + 4, namespace_length);
+        table.write_u16(device + 6, namespace_offset);
+        table.write_u16(device + 12, 0x8000); // Serial port
+        table.write_u16(device + 14, 0x0003); // ARM PL011
+        table.write_u16(device + 18, base_address_offset);
+        table.write_u16(device + 20, address_size_offset);
+        table.write(
+            device + base_address_offset as usize,
+            GenericAddress::mmio_address::<u32>(config.base_address),
+        );
+        table.write_u32(device + address_size_offset as usize, config.address_size);
+        let namespace = device + namespace_offset as usize;
+        table.write_bytes(namespace, config.namespace.as_bytes());
+        table.write_u8(namespace + config.namespace.len(), 0);
+
+        Self { table }
+    }
+}
+
+impl Aml for DBG2 {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        self.table.to_aml_bytes(sink);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    #[should_panic]
+    fn test_dbg2_rejects_oversized_namespace() {
+        let namespace = "a".repeat(u16::MAX as usize);
+        let _ = DBG2::pl011(
+            *b"RUSTVM",
+            *b"TESTDBG2",
+            1,
+            Pl011Config {
+                base_address: 0,
+                address_size: 0x1000,
+                namespace: &namespace,
+            },
+        );
+    }
+
+    #[test]
+    fn test_dbg2_pl011() {
+        let table = DBG2::pl011(
+            *b"RUSTVM",
+            *b"TESTDBG2",
+            1,
+            Pl011Config {
+                base_address: 0x6000_0000,
+                address_size: 0x1000,
+                namespace: "\\_SB.COM0",
+            },
+        );
+        let mut bytes = Vec::new();
+        table.to_aml_bytes(&mut bytes);
+
+        assert_eq!(
+            bytes.iter().fold(0u8, |sum, byte| sum.wrapping_add(*byte)),
+            0
+        );
+        assert_eq!(u32::from_le_bytes(bytes[40..44].try_into().unwrap()), 1);
+        assert_eq!(
+            u16::from_le_bytes(bytes[56..58].try_into().unwrap()),
+            0x8000
+        );
+        assert_eq!(u16::from_le_bytes(bytes[58..60].try_into().unwrap()), 3);
+        assert_eq!(
+            u64::from_le_bytes(bytes[70..78].try_into().unwrap()),
+            0x6000_0000,
+        );
+        assert_eq!(&bytes[82..92], b"\\_SB.COM0\0");
+    }
+}

--- a/acpi_tables/src/gtdt.rs
+++ b/acpi_tables/src/gtdt.rs
@@ -1,0 +1,337 @@
+// Copyright 2026 Arthur Heymans
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generic Timer Description Table (GTDT).
+
+extern crate alloc;
+
+use crate::{sdt::Sdt, Aml, AmlSink};
+
+const TABLE_LENGTH: usize = 104;
+const TIMER_BLOCK_LENGTH: usize = 20;
+const TIMER_FRAME_LENGTH: usize = 40;
+const WATCHDOG_LENGTH: usize = 28;
+
+/// Physical address value used when a GTDT register block is not present.
+pub const ADDRESS_NOT_PRESENT: u64 = u64::MAX;
+
+/// Flags for the fixed GTDT timer entries.
+pub mod timer_flags {
+    pub const EDGE_TRIGGERED: u32 = 1 << 0;
+    pub const ACTIVE_LOW: u32 = 1 << 1;
+    pub const ALWAYS_ON: u32 = 1 << 2;
+}
+
+/// Interrupt flags for a GT Block timer frame.
+pub mod frame_timer_flags {
+    pub const EDGE_TRIGGERED: u32 = 1 << 0;
+    pub const ACTIVE_LOW: u32 = 1 << 1;
+}
+
+/// Common flags for a GT Block timer frame.
+pub mod frame_common_flags {
+    pub const SECURE: u32 = 1 << 0;
+    pub const ALWAYS_ON: u32 = 1 << 1;
+}
+
+/// Flags for an Arm Generic Watchdog.
+pub mod watchdog_flags {
+    pub const EDGE_TRIGGERED: u32 = 1 << 0;
+    pub const ACTIVE_LOW: u32 = 1 << 1;
+    pub const SECURE: u32 = 1 << 2;
+}
+
+/// A timer interrupt and its context-specific flags.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TimerInterrupt {
+    pub gsiv: u32,
+    pub flags: u32,
+}
+
+/// One timer frame in a [`TimerBlock`].
+#[derive(Clone, Copy, Debug)]
+pub struct TimerFrame {
+    pub frame_number: u8,
+    pub base_address: u64,
+    pub el0_base_address: u64,
+    pub physical_timer: TimerInterrupt,
+    pub virtual_timer: TimerInterrupt,
+    pub common_flags: u32,
+}
+
+/// A Generic Timer Block platform timer structure.
+#[derive(Clone, Copy, Debug)]
+pub struct TimerBlock<'a> {
+    pub control_base: u64,
+    pub frames: &'a [TimerFrame],
+}
+
+/// An Arm Generic Watchdog platform timer structure.
+#[derive(Clone, Copy, Debug)]
+pub struct Watchdog {
+    pub refresh_base: u64,
+    pub control_base: u64,
+    pub timer: TimerInterrupt,
+}
+
+/// A GTDT platform timer structure.
+#[derive(Clone, Copy, Debug)]
+pub enum PlatformTimer<'a> {
+    TimerBlock(TimerBlock<'a>),
+    Watchdog(Watchdog),
+}
+
+impl PlatformTimer<'_> {
+    fn encoded_len(&self) -> usize {
+        match self {
+            Self::TimerBlock(block) => {
+                assert!((1..=8).contains(&block.frames.len()));
+                TIMER_BLOCK_LENGTH + block.frames.len() * TIMER_FRAME_LENGTH
+            }
+            Self::Watchdog(_) => WATCHDOG_LENGTH,
+        }
+    }
+
+    fn write(&self, table: &mut Sdt, offset: usize) {
+        match self {
+            Self::TimerBlock(block) => {
+                let length = self.encoded_len();
+                table.write_u8(offset, 0);
+                table.write_u16(offset + 1, length as u16);
+                table.write_u64(offset + 4, block.control_base);
+                table.write_u32(offset + 12, block.frames.len() as u32);
+                table.write_u32(offset + 16, TIMER_BLOCK_LENGTH as u32);
+
+                for (index, frame) in block.frames.iter().enumerate() {
+                    assert!(frame.frame_number < 8);
+                    let frame_offset = offset + TIMER_BLOCK_LENGTH + index * TIMER_FRAME_LENGTH;
+                    table.write_u8(frame_offset, frame.frame_number);
+                    table.write_u64(frame_offset + 4, frame.base_address);
+                    table.write_u64(frame_offset + 12, frame.el0_base_address);
+                    table.write_u32(frame_offset + 20, frame.physical_timer.gsiv);
+                    table.write_u32(frame_offset + 24, frame.physical_timer.flags);
+                    table.write_u32(frame_offset + 28, frame.virtual_timer.gsiv);
+                    table.write_u32(frame_offset + 32, frame.virtual_timer.flags);
+                    table.write_u32(frame_offset + 36, frame.common_flags);
+                }
+            }
+            Self::Watchdog(watchdog) => {
+                table.write_u8(offset, 1);
+                table.write_u16(offset + 1, WATCHDOG_LENGTH as u16);
+                table.write_u64(offset + 4, watchdog.refresh_base);
+                table.write_u64(offset + 12, watchdog.control_base);
+                table.write_u32(offset + 20, watchdog.timer.gsiv);
+                table.write_u32(offset + 24, watchdog.timer.flags);
+            }
+        }
+    }
+}
+
+/// GTDT configuration for Arm generic timers.
+#[derive(Clone, Copy, Debug)]
+pub struct Config<'a> {
+    pub counter_control_base: u64,
+    pub secure_el1_timer: TimerInterrupt,
+    pub nonsecure_el1_timer: TimerInterrupt,
+    pub virtual_el1_timer: TimerInterrupt,
+    pub nonsecure_el2_timer: TimerInterrupt,
+    pub counter_read_base: u64,
+    pub virtual_el2_timer: TimerInterrupt,
+    pub platform_timers: &'a [PlatformTimer<'a>],
+}
+
+/// Generic Timer Description Table.
+pub struct GTDT {
+    table: Sdt,
+}
+
+impl GTDT {
+    /// Create a complete revision 3 GTDT.
+    pub fn new(
+        oem_id: [u8; 6],
+        oem_table_id: [u8; 8],
+        oem_revision: u32,
+        config: Config<'_>,
+    ) -> Self {
+        let length = config
+            .platform_timers
+            .iter()
+            .try_fold(TABLE_LENGTH, |length, timer| {
+                length.checked_add(timer.encoded_len())
+            })
+            .expect("GTDT length overflow");
+        let mut table = Sdt::new(
+            *b"GTDT",
+            u32::try_from(length).expect("GTDT exceeds the ACPI table length field"),
+            3,
+            oem_id,
+            oem_table_id,
+            oem_revision,
+        );
+
+        table.write_u64(36, config.counter_control_base);
+        table.write_u32(48, config.secure_el1_timer.gsiv);
+        table.write_u32(52, config.secure_el1_timer.flags);
+        table.write_u32(56, config.nonsecure_el1_timer.gsiv);
+        table.write_u32(60, config.nonsecure_el1_timer.flags);
+        table.write_u32(64, config.virtual_el1_timer.gsiv);
+        table.write_u32(68, config.virtual_el1_timer.flags);
+        table.write_u32(72, config.nonsecure_el2_timer.gsiv);
+        table.write_u32(76, config.nonsecure_el2_timer.flags);
+        table.write_u64(80, config.counter_read_base);
+        table.write_u32(
+            88,
+            u32::try_from(config.platform_timers.len())
+                .expect("GTDT platform timer count exceeds u32"),
+        );
+        table.write_u32(
+            92,
+            if config.platform_timers.is_empty() {
+                0
+            } else {
+                TABLE_LENGTH as u32
+            },
+        );
+        table.write_u32(96, config.virtual_el2_timer.gsiv);
+        table.write_u32(100, config.virtual_el2_timer.flags);
+
+        let mut offset = TABLE_LENGTH;
+        for platform_timer in config.platform_timers {
+            platform_timer.write(&mut table, offset);
+            offset += platform_timer.encoded_len();
+        }
+
+        Self { table }
+    }
+}
+
+impl Aml for GTDT {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        self.table.to_aml_bytes(sink);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_complete_gtdt() {
+        let frames = [TimerFrame {
+            frame_number: 3,
+            base_address: 0x1000,
+            el0_base_address: 0x2000,
+            physical_timer: TimerInterrupt {
+                gsiv: 40,
+                flags: frame_timer_flags::ACTIVE_LOW,
+            },
+            virtual_timer: TimerInterrupt {
+                gsiv: 41,
+                flags: frame_timer_flags::EDGE_TRIGGERED,
+            },
+            common_flags: frame_common_flags::SECURE | frame_common_flags::ALWAYS_ON,
+        }];
+        let platform_timers = [
+            PlatformTimer::TimerBlock(TimerBlock {
+                control_base: 0x3000,
+                frames: &frames,
+            }),
+            PlatformTimer::Watchdog(Watchdog {
+                refresh_base: 0x4000,
+                control_base: 0x5000,
+                timer: TimerInterrupt {
+                    gsiv: 48,
+                    flags: watchdog_flags::ACTIVE_LOW | watchdog_flags::SECURE,
+                },
+            }),
+        ];
+        let table = GTDT::new(
+            *b"RUSTVM",
+            *b"TESTGTDT",
+            1,
+            Config {
+                counter_control_base: 0x6000,
+                secure_el1_timer: TimerInterrupt { gsiv: 29, flags: 1 },
+                nonsecure_el1_timer: TimerInterrupt { gsiv: 30, flags: 2 },
+                virtual_el1_timer: TimerInterrupt { gsiv: 27, flags: 3 },
+                nonsecure_el2_timer: TimerInterrupt { gsiv: 26, flags: 4 },
+                counter_read_base: 0x7000,
+                virtual_el2_timer: TimerInterrupt { gsiv: 28, flags: 5 },
+                platform_timers: &platform_timers,
+            },
+        );
+        let mut bytes = Vec::new();
+        table.to_aml_bytes(&mut bytes);
+
+        assert_eq!(bytes.len(), TABLE_LENGTH + 60 + WATCHDOG_LENGTH);
+        assert_eq!(
+            bytes.iter().fold(0u8, |sum, byte| sum.wrapping_add(*byte)),
+            0
+        );
+        assert_eq!(
+            u64::from_le_bytes(bytes[80..88].try_into().unwrap()),
+            0x7000
+        );
+        assert_eq!(u32::from_le_bytes(bytes[88..92].try_into().unwrap()), 2);
+        assert_eq!(u32::from_le_bytes(bytes[96..100].try_into().unwrap()), 28);
+
+        let block = TABLE_LENGTH;
+        assert_eq!(bytes[block], 0);
+        assert_eq!(
+            u16::from_le_bytes(bytes[block + 1..block + 3].try_into().unwrap()),
+            60
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[block + 12..block + 16].try_into().unwrap()),
+            1
+        );
+        let frame = block + TIMER_BLOCK_LENGTH;
+        assert_eq!(bytes[frame], 3);
+        assert_eq!(
+            u64::from_le_bytes(bytes[frame + 4..frame + 12].try_into().unwrap()),
+            0x1000
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[frame + 36..frame + 40].try_into().unwrap()),
+            3
+        );
+
+        let watchdog = block + 60;
+        assert_eq!(bytes[watchdog], 1);
+        assert_eq!(
+            u16::from_le_bytes(bytes[watchdog + 1..watchdog + 3].try_into().unwrap()),
+            28
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[watchdog + 20..watchdog + 24].try_into().unwrap()),
+            48
+        );
+    }
+
+    #[test]
+    fn test_gtdt_without_platform_timers() {
+        let table = GTDT::new(
+            *b"RUSTVM",
+            *b"TESTGTDT",
+            1,
+            Config {
+                counter_control_base: ADDRESS_NOT_PRESENT,
+                secure_el1_timer: TimerInterrupt::default(),
+                nonsecure_el1_timer: TimerInterrupt::default(),
+                virtual_el1_timer: TimerInterrupt::default(),
+                nonsecure_el2_timer: TimerInterrupt::default(),
+                counter_read_base: ADDRESS_NOT_PRESENT,
+                virtual_el2_timer: TimerInterrupt::default(),
+                platform_timers: &[],
+            },
+        );
+        let mut bytes = Vec::new();
+        table.to_aml_bytes(&mut bytes);
+
+        assert_eq!(bytes.len(), TABLE_LENGTH);
+        assert_eq!(u32::from_le_bytes(bytes[88..92].try_into().unwrap()), 0);
+        assert_eq!(u32::from_le_bytes(bytes[92..96].try_into().unwrap()), 0);
+    }
+}

--- a/acpi_tables/src/hpet.rs
+++ b/acpi_tables/src/hpet.rs
@@ -1,0 +1,171 @@
+// Copyright 2026 Arthur Heymans
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! High Precision Event Timer table (HPET).
+
+extern crate alloc;
+
+use crate::{sdt::GenericAddress, sdt::Sdt, Aml, AmlSink};
+
+/// Width of the HPET main counter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CounterSize {
+    Bits32,
+    Bits64,
+}
+
+/// Fields copied from the HPET General Capabilities and ID register.
+#[derive(Clone, Copy, Debug)]
+pub struct EventTimerBlockId {
+    pub hardware_revision: u8,
+    pub comparator_count: u8,
+    pub counter_size: CounterSize,
+    pub legacy_replacement: bool,
+    pub pci_vendor_id: u16,
+}
+
+impl EventTimerBlockId {
+    fn encode(self) -> u32 {
+        assert!((3..=32).contains(&self.comparator_count));
+
+        u32::from(self.hardware_revision)
+            | (u32::from(self.comparator_count - 1) << 8)
+            | (u32::from(self.counter_size == CounterSize::Bits64) << 13)
+            | (u32::from(self.legacy_replacement) << 15)
+            | (u32::from(self.pci_vendor_id) << 16)
+    }
+}
+
+/// Page protection guaranteed for the HPET register block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PageProtection {
+    None = 0,
+    Protected4KiB = 1,
+    Protected64KiB = 2,
+}
+
+/// HPET configuration.
+#[derive(Clone, Copy, Debug)]
+pub struct Config {
+    pub event_timer_block_id: EventTimerBlockId,
+    pub base_address: u64,
+    pub number: u8,
+    pub minimum_tick: u16,
+    pub page_protection: PageProtection,
+    pub oem_attribute: u8,
+}
+
+/// High Precision Event Timer table.
+pub struct HPET {
+    table: Sdt,
+}
+
+impl HPET {
+    /// Create a complete revision 1 HPET table.
+    pub fn new(oem_id: [u8; 6], oem_table_id: [u8; 8], oem_revision: u32, config: Config) -> Self {
+        assert_eq!(config.base_address & 0x3ff, 0);
+        assert!(config.oem_attribute <= 0x0f);
+
+        let mut table = Sdt::new(*b"HPET", 56, 1, oem_id, oem_table_id, oem_revision);
+        table.write_u32(36, config.event_timer_block_id.encode());
+        table.write(
+            40,
+            GenericAddress {
+                address_space_id: 0,
+                register_bit_width: 64,
+                register_bit_offset: 0,
+                access_size: 0,
+                address: config.base_address,
+            },
+        );
+        table.write_u8(52, config.number);
+        table.write_u16(53, config.minimum_tick);
+        table.write_u8(
+            55,
+            (config.oem_attribute << 4) | config.page_protection as u8,
+        );
+
+        Self { table }
+    }
+}
+
+impl Aml for HPET {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        self.table.to_aml_bytes(sink);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_complete_hpet() {
+        let table = HPET::new(
+            *b"RUSTVM",
+            *b"TESTHPET",
+            1,
+            Config {
+                event_timer_block_id: EventTimerBlockId {
+                    hardware_revision: 0xa5,
+                    comparator_count: 32,
+                    counter_size: CounterSize::Bits64,
+                    legacy_replacement: true,
+                    pci_vendor_id: 0x8086,
+                },
+                base_address: 0xfed0_0000,
+                number: 3,
+                minimum_tick: 128,
+                page_protection: PageProtection::Protected64KiB,
+                oem_attribute: 0xb,
+            },
+        );
+        let mut bytes = Vec::new();
+        table.to_aml_bytes(&mut bytes);
+
+        assert_eq!(bytes.len(), 56);
+        assert_eq!(
+            bytes.iter().fold(0u8, |sum, byte| sum.wrapping_add(*byte)),
+            0
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[36..40].try_into().unwrap()),
+            0x8086_bfa5,
+        );
+        assert_eq!(bytes[40..44], [0, 64, 0, 0]);
+        assert_eq!(
+            u64::from_le_bytes(bytes[44..52].try_into().unwrap()),
+            0xfed0_0000
+        );
+        assert_eq!(bytes[52], 3);
+        assert_eq!(u16::from_le_bytes(bytes[53..55].try_into().unwrap()), 128);
+        assert_eq!(bytes[55], 0xb2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_hpet_rejects_invalid_comparator_count() {
+        let _ = HPET::new(
+            *b"RUSTVM",
+            *b"TESTHPET",
+            1,
+            Config {
+                event_timer_block_id: EventTimerBlockId {
+                    hardware_revision: 1,
+                    comparator_count: 2,
+                    counter_size: CounterSize::Bits32,
+                    legacy_replacement: false,
+                    pci_vendor_id: 0,
+                },
+                base_address: 0,
+                number: 0,
+                minimum_tick: 0,
+                page_protection: PageProtection::None,
+                oem_attribute: 0,
+            },
+        );
+    }
+}

--- a/acpi_tables/src/iort.rs
+++ b/acpi_tables/src/iort.rs
@@ -1,0 +1,230 @@
+// Copyright 2026 Arthur Heymans
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! IO Remapping Table (IORT) support.
+
+extern crate alloc;
+
+use crate::{sdt::Sdt, Aml, AmlSink};
+
+const TABLE_HEADER_LENGTH: usize = 48;
+const NODE_HEADER_LENGTH: usize = 16;
+const ROOT_COMPLEX_DATA_LENGTH: usize = 24;
+const ID_MAPPING_LENGTH: usize = 20;
+
+/// Allocation hints for PCI Root Complex memory accesses.
+pub mod allocation_hints {
+    pub const TRANSIENT: u8 = 1 << 0;
+    pub const WRITE: u8 = 1 << 1;
+    pub const READ: u8 = 1 << 2;
+    pub const OVERRIDE: u8 = 1 << 3;
+}
+
+/// Flags describing PCI Root Complex memory accesses.
+pub mod memory_access_flags {
+    pub const COHERENT_PATH_TO_MEMORY: u8 = 1 << 0;
+    pub const DEVICE_ATTRIBUTES_CACHEABLE_SHAREABLE: u8 = 1 << 1;
+    pub const CAN_WRITE_BACK_SNOOPS: u8 = 1 << 2;
+}
+
+/// PCI Root Complex ATS attributes.
+pub mod ats_attributes {
+    pub const ATS_SUPPORTED: u32 = 1 << 0;
+    pub const PRI_SUPPORTED: u32 = 1 << 1;
+    pub const PASID_FORWARDING_SUPPORTED: u32 = 1 << 2;
+}
+
+/// PCI Root Complex node flags.
+pub mod root_complex_flags {
+    pub const PASID_SUPPORTED: u32 = 1 << 0;
+}
+
+/// Memory access properties advertised by a PCI Root Complex node.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MemoryAccessProperties {
+    pub cache_coherent: bool,
+    pub allocation_hints: u8,
+    pub flags: u8,
+}
+
+impl MemoryAccessProperties {
+    fn encode(self) -> u64 {
+        assert_eq!(self.allocation_hints & !0x0f, 0);
+        assert_eq!(self.flags & !0x07, 0);
+
+        u64::from(self.cache_coherent)
+            | (u64::from(self.allocation_hints) << 32)
+            | (u64::from(self.flags) << 56)
+    }
+}
+
+/// Configuration for an ITS Group and PCI Root Complex IORT.
+pub struct Config<'a> {
+    pub its_ids: &'a [u32],
+    pub pci_segment: u32,
+    pub memory_access_properties: MemoryAccessProperties,
+    pub ats_attributes: u32,
+    pub memory_address_limit: u8,
+    pub pasid_capabilities: u16,
+    pub root_complex_flags: u32,
+    pub id_count: u32,
+}
+
+/// IO Remapping Table.
+pub struct IORT {
+    table: Sdt,
+}
+
+impl IORT {
+    /// Create a revision 6 IORT with one ITS Group and one PCI Root Complex.
+    pub fn new(
+        oem_id: [u8; 6],
+        oem_table_id: [u8; 8],
+        oem_revision: u32,
+        config: Config<'_>,
+    ) -> Self {
+        assert!(!config.its_ids.is_empty());
+        assert!(config.id_count > 0);
+        assert_eq!(config.ats_attributes & !0x07, 0);
+        assert!(config.pasid_capabilities <= 20);
+        assert_eq!(config.root_complex_flags & !0x01, 0);
+
+        let its_node_length = NODE_HEADER_LENGTH + 4 + config.its_ids.len() * 4;
+        let root_complex_length = NODE_HEADER_LENGTH + ROOT_COMPLEX_DATA_LENGTH + ID_MAPPING_LENGTH;
+        let length = TABLE_HEADER_LENGTH + its_node_length + root_complex_length;
+        assert!(its_node_length <= u16::MAX as usize);
+
+        let mut table = Sdt::new(
+            *b"IORT",
+            length as u32,
+            6,
+            oem_id,
+            oem_table_id,
+            oem_revision,
+        );
+
+        table.write_u32(36, 2); // Node count
+        table.write_u32(40, TABLE_HEADER_LENGTH as u32);
+
+        let its_offset = TABLE_HEADER_LENGTH;
+        table.write_u8(its_offset, 0); // ITS Group
+        table.write_u16(its_offset + 1, its_node_length as u16);
+        table.write_u8(its_offset + 3, 1); // Node revision
+        table.write_u32(its_offset + NODE_HEADER_LENGTH, config.its_ids.len() as u32);
+        for (index, &identifier) in config.its_ids.iter().enumerate() {
+            table.write_u32(its_offset + NODE_HEADER_LENGTH + 4 + index * 4, identifier);
+        }
+
+        let root_offset = its_offset + its_node_length;
+        table.write_u8(root_offset, 2); // PCI Root Complex
+        table.write_u16(root_offset + 1, root_complex_length as u16);
+        table.write_u8(root_offset + 3, 4); // Node revision
+        table.write_u32(root_offset + 4, 1); // Identifier
+        table.write_u32(root_offset + 8, 1); // Mapping count
+        table.write_u32(
+            root_offset + 12,
+            (NODE_HEADER_LENGTH + ROOT_COMPLEX_DATA_LENGTH) as u32,
+        );
+
+        let root_data = root_offset + NODE_HEADER_LENGTH;
+        table.write_u64(root_data, config.memory_access_properties.encode());
+        table.write_u32(root_data + 8, config.ats_attributes);
+        table.write_u32(root_data + 12, config.pci_segment);
+        table.write_u8(root_data + 16, config.memory_address_limit);
+        table.write_u16(root_data + 17, config.pasid_capabilities);
+        table.write_u32(root_data + 20, config.root_complex_flags);
+
+        let mapping = root_data + ROOT_COMPLEX_DATA_LENGTH;
+        table.write_u32(mapping + 4, config.id_count - 1);
+        table.write_u32(mapping + 12, its_offset as u32);
+
+        Self { table }
+    }
+}
+
+impl Aml for IORT {
+    fn to_aml_bytes(&self, sink: &mut dyn AmlSink) {
+        self.table.to_aml_bytes(sink);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn test_iort() {
+        let table = IORT::new(
+            *b"RUSTVM",
+            *b"TESTIORT",
+            1,
+            Config {
+                its_ids: &[0, 1],
+                pci_segment: 2,
+                memory_access_properties: MemoryAccessProperties {
+                    cache_coherent: true,
+                    allocation_hints: allocation_hints::WRITE | allocation_hints::READ,
+                    flags: memory_access_flags::COHERENT_PATH_TO_MEMORY
+                        | memory_access_flags::DEVICE_ATTRIBUTES_CACHEABLE_SHAREABLE,
+                },
+                ats_attributes: ats_attributes::ATS_SUPPORTED
+                    | ats_attributes::PRI_SUPPORTED
+                    | ats_attributes::PASID_FORWARDING_SUPPORTED,
+                memory_address_limit: 48,
+                pasid_capabilities: 20,
+                root_complex_flags: root_complex_flags::PASID_SUPPORTED,
+                id_count: 0x1_0000,
+            },
+        );
+        let mut bytes = Vec::new();
+        table.to_aml_bytes(&mut bytes);
+
+        assert_eq!(
+            bytes.iter().fold(0u8, |sum, byte| sum.wrapping_add(*byte)),
+            0
+        );
+        assert_eq!(u32::from_le_bytes(bytes[36..40].try_into().unwrap()), 2);
+        assert_eq!(u16::from_le_bytes(bytes[49..51].try_into().unwrap()), 28);
+
+        let root_offset = 48 + 28;
+        assert_eq!(bytes[root_offset], 2);
+        assert_eq!(
+            u32::from_le_bytes(
+                bytes[root_offset + 28..root_offset + 32]
+                    .try_into()
+                    .unwrap()
+            ),
+            2,
+        );
+        let root_data = root_offset + NODE_HEADER_LENGTH;
+        assert_eq!(
+            u64::from_le_bytes(bytes[root_data..root_data + 8].try_into().unwrap()),
+            0x0300_0006_0000_0001,
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[root_data + 8..root_data + 12].try_into().unwrap()),
+            7,
+        );
+        assert_eq!(bytes[root_offset + 32], 48);
+        assert_eq!(
+            u16::from_le_bytes(bytes[root_data + 17..root_data + 19].try_into().unwrap()),
+            20,
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[root_data + 20..root_data + 24].try_into().unwrap()),
+            root_complex_flags::PASID_SUPPORTED,
+        );
+
+        let mapping = root_offset + NODE_HEADER_LENGTH + ROOT_COMPLEX_DATA_LENGTH;
+        assert_eq!(
+            u32::from_le_bytes(bytes[mapping + 4..mapping + 8].try_into().unwrap()),
+            0xffff,
+        );
+        assert_eq!(
+            u32::from_le_bytes(bytes[mapping + 12..mapping + 16].try_into().unwrap()),
+            48,
+        );
+    }
+}

--- a/acpi_tables/src/lib.rs
+++ b/acpi_tables/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod aml;
 pub mod bert;
 pub mod cedt;
+pub mod dbg2;
 pub mod facs;
 pub mod fadt;
 pub mod gas;

--- a/acpi_tables/src/lib.rs
+++ b/acpi_tables/src/lib.rs
@@ -15,6 +15,7 @@ pub mod cedt;
 pub mod facs;
 pub mod fadt;
 pub mod gas;
+pub mod gtdt;
 pub mod hest;
 pub mod hmat;
 pub mod madt;

--- a/acpi_tables/src/lib.rs
+++ b/acpi_tables/src/lib.rs
@@ -25,6 +25,7 @@ pub mod rimt;
 pub mod rqsc;
 pub mod rsdp;
 pub mod sdt;
+pub mod sink;
 pub mod slit;
 pub mod spcr;
 pub mod srat;

--- a/acpi_tables/src/lib.rs
+++ b/acpi_tables/src/lib.rs
@@ -18,6 +18,7 @@ pub mod gas;
 pub mod gtdt;
 pub mod hest;
 pub mod hmat;
+pub mod iort;
 pub mod madt;
 pub mod mcfg;
 pub mod pptt;

--- a/acpi_tables/src/lib.rs
+++ b/acpi_tables/src/lib.rs
@@ -19,6 +19,7 @@ pub mod gas;
 pub mod gtdt;
 pub mod hest;
 pub mod hmat;
+pub mod hpet;
 pub mod iort;
 pub mod madt;
 pub mod mcfg;

--- a/acpi_tables/src/sink.rs
+++ b/acpi_tables/src/sink.rs
@@ -1,0 +1,91 @@
+// Copyright 2026 Arthur Heymans
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! [`AmlSink`] implementations.
+
+use crate::AmlSink;
+
+/// AML sink backed by a fixed-size byte buffer.
+///
+/// Writes bytes sequentially and panics if the buffer is too small.
+pub struct FixedBufSink<'a> {
+    buffer: &'a mut [u8],
+    position: usize,
+}
+
+impl<'a> FixedBufSink<'a> {
+    /// Create a sink that writes at the start of `buffer`.
+    pub fn new(buffer: &'a mut [u8]) -> Self {
+        Self {
+            buffer,
+            position: 0,
+        }
+    }
+
+    /// Return the number of bytes written.
+    pub fn position(&self) -> usize {
+        self.position
+    }
+
+    /// Return the remaining capacity.
+    pub fn remaining(&self) -> usize {
+        self.buffer.len() - self.position
+    }
+
+    /// Return the bytes written so far.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buffer[..self.position]
+    }
+}
+
+impl AmlSink for FixedBufSink<'_> {
+    fn byte(&mut self, byte: u8) {
+        assert!(
+            self.position < self.buffer.len(),
+            "FixedBufSink overflow: wrote {} bytes into {}-byte buffer",
+            self.position + 1,
+            self.buffer.len(),
+        );
+        self.buffer[self.position] = byte;
+        self.position += 1;
+    }
+
+    fn vec(&mut self, bytes: &[u8]) {
+        let end = self.position + bytes.len();
+        assert!(
+            end <= self.buffer.len(),
+            "FixedBufSink overflow: need {} bytes, buffer has {} remaining",
+            bytes.len(),
+            self.remaining(),
+        );
+        self.buffer[self.position..end].copy_from_slice(bytes);
+        self.position = end;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Aml;
+
+    #[test]
+    fn fixed_buffer_sink_writes_aml() {
+        let mut buffer = [0u8; 8];
+        let mut sink = FixedBufSink::new(&mut buffer);
+
+        0x1234u16.to_aml_bytes(&mut sink);
+
+        assert_eq!(sink.as_slice(), b"\x0b\x34\x12");
+        assert_eq!(sink.position(), 3);
+        assert_eq!(sink.remaining(), 5);
+    }
+
+    #[test]
+    #[should_panic(expected = "FixedBufSink overflow")]
+    fn fixed_buffer_sink_panics_on_overflow() {
+        let mut buffer = [0u8; 2];
+        let mut sink = FixedBufSink::new(&mut buffer);
+        sink.vec(&[1, 2, 3]);
+    }
+}

--- a/acpi_tables/src/spcr.rs
+++ b/acpi_tables/src/spcr.rs
@@ -26,10 +26,16 @@ pub struct SPCR<'a> {
 }
 
 impl SPCR<'_> {
-    pub fn sbi(oem_id: [u8; 6], oem_table_id: [u8; 8], oem_revision: u32) -> Self {
+    fn new(
+        oem_id: [u8; 6],
+        oem_table_id: [u8; 8],
+        oem_revision: u32,
+        info: SerialPortInfo,
+    ) -> Self {
         let mut header = TableHeader {
             signature: *b"SPCR",
-            length: (TableHeader::len() as u32).into(),
+            length: ((TableHeader::len() + SerialPortInfo::len() + EMPTY_NAMESPACE.len()) as u32)
+                .into(),
             revision: 4,
             checksum: 0,
             oem_id,
@@ -38,19 +44,38 @@ impl SPCR<'_> {
             creator_id: crate::CREATOR_ID,
             creator_revision: crate::CREATOR_REVISION,
         };
-        let sbi = SerialPortInfo::sbi();
 
-        let mut cksum = Checksum::default();
-        cksum.append(header.as_bytes());
-        cksum.append(sbi.as_bytes());
-        cksum.append(&EMPTY_NAMESPACE);
-        header.checksum = cksum.value();
+        let mut checksum = Checksum::default();
+        checksum.append(header.as_bytes());
+        checksum.append(info.as_bytes());
+        checksum.append(&EMPTY_NAMESPACE);
+        header.checksum = checksum.value();
 
         Self {
             header,
-            info: sbi,
+            info,
             namespace_string: &EMPTY_NAMESPACE,
         }
+    }
+
+    pub fn sbi(oem_id: [u8; 6], oem_table_id: [u8; 8], oem_revision: u32) -> Self {
+        Self::new(oem_id, oem_table_id, oem_revision, SerialPortInfo::sbi())
+    }
+
+    /// Create an SPCR for an ARM PL011 UART using a GIC interrupt.
+    pub fn pl011(
+        oem_id: [u8; 6],
+        oem_table_id: [u8; 8],
+        oem_revision: u32,
+        base_address: u64,
+        gsi: u32,
+    ) -> Self {
+        Self::new(
+            oem_id,
+            oem_table_id,
+            oem_revision,
+            SerialPortInfo::pl011(base_address, gsi),
+        )
     }
 }
 
@@ -160,6 +185,40 @@ impl SerialPortInfo {
             namespace_string_offset: (Self::len() as u16).into(),
         }
     }
+
+    pub fn pl011(base_address: u64, gsi: u32) -> Self {
+        Self {
+            interface_type: SerialPortSubType::ArmPl011 as u8,
+            reserved0: [0; 3],
+            base_address: gas::GAS::new(
+                gas::AddressSpace::SystemMemory,
+                32,
+                0,
+                gas::AccessSize::DwordAccess,
+                base_address,
+            ),
+            interrupt_type: 0x08,
+            irq: 0,
+            gsi: gsi.into(),
+            baud_rate: 7, // 115200 baud
+            parity: 0,
+            stop_bits: 1,
+            flow_control: 0,
+            terminal_type: 0,
+            language: 0,
+            pci_device_id: PCI_DEVICE_ID_NONE.into(),
+            pci_vendor_id: PCI_VENDOR_ID_NONE.into(),
+            pci_bus: 0,
+            pci_device: 0,
+            pci_function: 0,
+            pci_flags: 0.into(),
+            pci_segment: 0,
+            clock_frequency: 0.into(),
+            precise_baud: 0.into(),
+            namespace_string_len: (EMPTY_NAMESPACE.len() as u16).into(),
+            namespace_string_offset: (Self::len() as u16).into(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -177,5 +236,26 @@ mod tests {
         assert_eq!(sum, 0);
         assert_eq!(bytes.len(), TableHeader::len() + SerialPortInfo::len() + 2);
         assert_eq!(bytes[0..4], *b"SPCR");
+        assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 90);
+    }
+
+    #[test]
+    fn test_pl011_spcr() {
+        let spcr = SPCR::pl011(*b"SSPCRR", *b"SOMETHIN", 1, 0x6000_0000, 33);
+        let mut bytes = Vec::new();
+        spcr.to_aml_bytes(&mut bytes);
+
+        assert_eq!(
+            bytes.iter().fold(0u8, |sum, byte| sum.wrapping_add(*byte)),
+            0
+        );
+        assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 90);
+        assert_eq!(bytes[36], SerialPortSubType::ArmPl011 as u8);
+        assert_eq!(
+            u64::from_le_bytes(bytes[44..52].try_into().unwrap()),
+            0x6000_0000
+        );
+        assert_eq!(u32::from_le_bytes(bytes[54..58].try_into().unwrap()), 33);
+        assert_eq!(bytes[58], 7);
     }
 }


### PR DESCRIPTION
The `acpi_tables` crate lacks several AML encoders and standard platform
tables needed by firmware implementations, especially Arm guests.

Add GPIO and serial-bus resources, a fixed AML sink, and GTDT, IORT,
DBG2, PL011 SPCR, and HPET table generation. Also fix the PowerResource
opcode ordering and SPCR table length.

The changes are split into a nine-part review stack:
https://github.com/ArthurHeymans/rust-vmm/pulls/10
