### PR TITLE
seccompiler: make apply_filter_with_flags public

### DIFF
--- a/seccompiler/CHANGELOG.md
+++ b/seccompiler/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Upcoming Release
 
+## Added
+- `apply_filter_with_flags` is now public, so callers can pass seccomp(2) flags such as `SECCOMP_FILTER_FLAG_TSYNC` and `SECCOMP_FILTER_FLAG_LOG` when installing a filter, instead of reimplementing the syscall.
+
 # v0.5.0
 
 ## Added

--- a/seccompiler/src/lib.rs
+++ b/seccompiler/src/lib.rs
@@ -325,7 +325,47 @@ pub fn apply_filter_all_threads(bpf_filter: BpfProgramRef) -> Result<()> {
     apply_filter_with_flags(bpf_filter, libc::SECCOMP_FILTER_FLAG_TSYNC)
 }
 
-/// Apply a BPF filter to the calling thread.
+/// Apply a BPF filter, passing `flags` through to the seccomp syscall.
+///
+/// `flags` is a bitset of the `SECCOMP_FILTER_FLAG_*` values that `libc`
+/// defines. [`apply_filter`] and [`apply_filter_all_threads`] are presets of
+/// this function with `0` and `SECCOMP_FILTER_FLAG_TSYNC` respectively.
+///
+/// A combination worth knowing about is `SECCOMP_FILTER_FLAG_TSYNC` together
+/// with `SECCOMP_FILTER_FLAG_LOG`: synchronise the filter onto every thread
+/// of the process, and have the kernel record every refused syscall
+/// (syscall number, pid, comm) to the audit log (`dmesg` where auditd is
+/// absent), subject to `/proc/sys/kernel/seccomp/actions_logged`.
+///
+/// The LOG flag arrived with kernel 4.14; an older kernel rejects it with
+/// `EINVAL`. Callers that want the audit trail where available and the
+/// enforcement everywhere should retry without the flag:
+///
+/// ```
+/// use seccompiler::{apply_filter_with_flags, BpfProgram, Error, SeccompAction, SeccompFilter};
+/// use std::convert::TryInto;
+///
+/// // A filter that refuses getcwd and allows everything else.
+/// let filter: BpfProgram = SeccompFilter::new(
+///     vec![(libc::SYS_getcwd, vec![])].into_iter().collect(),
+///     SeccompAction::Allow,
+///     SeccompAction::Errno(libc::EPERM as u32),
+///     std::env::consts::ARCH.try_into().unwrap(),
+/// )
+/// .unwrap()
+/// .try_into()
+/// .unwrap();
+///
+/// let flags = libc::SECCOMP_FILTER_FLAG_TSYNC | libc::SECCOMP_FILTER_FLAG_LOG;
+/// match apply_filter_with_flags(&filter, flags) {
+///     Ok(()) => {}
+///     Err(Error::Seccomp(e)) if e.raw_os_error() == Some(libc::EINVAL) => {
+///         // Kernel older than 4.14: keep the enforcement, lose the logging.
+///         apply_filter_with_flags(&filter, libc::SECCOMP_FILTER_FLAG_TSYNC).unwrap();
+///     }
+///     Err(e) => panic!("failed to install filter: {:?}", e),
+/// }
+/// ```
 ///
 /// # Arguments
 ///
@@ -333,7 +373,9 @@ pub fn apply_filter_all_threads(bpf_filter: BpfProgramRef) -> Result<()> {
 /// * `flags` - A u64 representing a bitset of seccomp's flags parameter.
 ///
 /// [`BpfProgram`]: type.BpfProgram.html
-fn apply_filter_with_flags(bpf_filter: BpfProgramRef, flags: libc::c_ulong) -> Result<()> {
+/// [`apply_filter`]: fn.apply_filter.html
+/// [`apply_filter_all_threads`]: fn.apply_filter_all_threads.html
+pub fn apply_filter_with_flags(bpf_filter: BpfProgramRef, flags: libc::c_ulong) -> Result<()> {
     // If the program is empty, don't install the filter.
     if bpf_filter.is_empty() {
         return Err(Error::EmptyFilter);

--- a/seccompiler/tests/integration_tests.rs
+++ b/seccompiler/tests/integration_tests.rs
@@ -8,8 +8,8 @@ use std::collections::BTreeMap;
 use seccompiler::SeccompCmpArgLen::*;
 use seccompiler::SeccompCmpOp::*;
 use seccompiler::{
-    apply_filter, sock_filter, BpfProgram, Error, SeccompAction, SeccompCondition as Cond,
-    SeccompFilter, SeccompRule,
+    apply_filter, apply_filter_with_flags, sock_filter, BpfProgram, Error, SeccompAction,
+    SeccompCondition as Cond, SeccompFilter, SeccompRule,
 };
 use std::convert::TryInto;
 use std::env::consts::ARCH;
@@ -118,6 +118,63 @@ fn test_empty_filter() {
 
     // Check that the getpid syscall returned successfully.
     assert!(pid > 0);
+}
+
+#[test]
+fn test_apply_filter_with_flags() {
+    // An empty denylist filter allows every syscall; installing it with
+    // TSYNC | LOG exercises the flags path.
+    // Kernels older than 4.14 reject SECCOMP_FILTER_FLAG_LOG with EINVAL, in
+    // which case retry without it: the enforcement matters, the audit logging
+    // is best-effort.
+    let filter = SeccompFilter::new(
+        BTreeMap::new(),
+        SeccompAction::Allow,
+        SeccompAction::Errno(FAILURE_CODE as u32),
+        ARCH.try_into().unwrap(),
+    )
+    .unwrap();
+    let prog: BpfProgram = filter.try_into().unwrap();
+
+    // TSYNC synchronises the filter onto every thread of the process, so it
+    // must not be installed from a thread of the shared test binary.
+    // It would poison the harness's other threads, and a sibling thread
+    // holding its own filter would make the call fail with
+    // `Error::ThreadSync`.
+    // Fork instead, as `test_invalid_architecture` does: the child is
+    // single-threaded, so the sync trivially succeeds, and the filter dies
+    // with the child.
+    let pid = unsafe { libc::fork() };
+    match pid {
+        0 => {
+            // No assertion on the pre-install level: a container runtime may
+            // already have installed a filter, which is not this test's subject.
+            let flags = libc::SECCOMP_FILTER_FLAG_TSYNC | libc::SECCOMP_FILTER_FLAG_LOG;
+            match apply_filter_with_flags(&prog, flags) {
+                Ok(()) => {}
+                Err(Error::Seccomp(e)) if e.raw_os_error() == Some(libc::EINVAL) => {
+                    apply_filter_with_flags(&prog, libc::SECCOMP_FILTER_FLAG_TSYNC).unwrap();
+                }
+                Err(e) => panic!("failed to install filter: {:?}", e),
+            }
+
+            let seccomp_level = unsafe { libc::prctl(libc::PR_GET_SECCOMP) };
+            assert_eq!(seccomp_level, 2);
+
+            // `_exit` rather than `process::exit`: a forked child must not
+            // run atexit handlers or flush the parent's stdio buffers.
+            unsafe { libc::_exit(0) };
+        }
+        -1 => panic!("fork failed: {:?}", std::io::Error::last_os_error()),
+        child_pid => {
+            let mut child_status: i32 = -1;
+            let pid_done = unsafe { libc::waitpid(child_pid, &mut child_status, 0) };
+            assert_eq!(pid_done, child_pid);
+
+            assert!(libc::WIFEXITED(child_status));
+            assert_eq!(libc::WEXITSTATUS(child_status), 0);
+        }
+    };
 }
 
 #[test]


### PR DESCRIPTION
Makes `apply_filter_with_flags` public. The existing entry points `apply_filter` and `apply_filter_all_threads` are already presets of it with `0` and `SECCOMP_FILTER_FLAG_TSYNC`; publishing it gives callers the seccomp(2) flag combinations the presets cannot express.

The motivating combination is TSYNC | LOG. `SECCOMP_FILTER_FLAG_LOG` (since Linux 4.14, per seccomp(2)) makes a deny-list filter debuggable: every refusal becomes an audit line with syscall number, pid and comm instead of a bare EPERM.
Today, getting it means reimplementing the seccomp(2) call outside the crate.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
